### PR TITLE
Remove dependency on openidconnect

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,9 @@ serde_json = "1.0"
 serde_with = "3.3.0"
 serde_path_to_error = "0.1.14"
 url = { version = "2.3.1", features = ["serde"] }
-openidconnect = { version = "4.0.0-alpha.2", features = ["timing-resistant-secret-traits"] }
-oauth2 = "5.0.0-alpha.4"
+oauth2 = { version = "5.0.0-alpha.4", features = [
+    "timing-resistant-secret-traits",
+] }
 async-signature = "0.3.0"
 rand = "0.8.5"
 time = { version = "0.3.29", features = ["serde"] }
@@ -28,6 +29,8 @@ thiserror = "1.0.49"
 tracing = "0.1"
 base64 = "0.21.4"
 serde_urlencoded = "0.7.1"
+anyhow = "1.0.86"
+sha2 = "0.10.8"
 
 [dev-dependencies]
 assert-json-diff = "2.0.2"

--- a/src/authorization.rs
+++ b/src/authorization.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, marker::PhantomData};
+use std::borrow::Cow;
 
 use oauth2::{CsrfToken, PkceCodeChallenge};
 use serde::{Deserialize, Serialize};
@@ -9,25 +9,15 @@ use crate::{
     types::{IssuerState, IssuerUrl, UserHint},
 };
 
-pub struct AuthorizationRequest<'a, AD>
-where
-    AD: AuthorizationDetailsProfile,
-{
+pub struct AuthorizationRequest<'a> {
     inner: oauth2::AuthorizationRequest<'a>,
-    _pd: PhantomData<AD>,
 }
 
 // TODO 5.1.2 scopes
 
-impl<'a, AD> AuthorizationRequest<'a, AD>
-where
-    AD: AuthorizationDetailsProfile,
-{
+impl<'a> AuthorizationRequest<'a> {
     pub(crate) fn new(inner: oauth2::AuthorizationRequest<'a>) -> Self {
-        Self {
-            inner,
-            _pd: PhantomData,
-        }
+        Self { inner }
     }
 
     pub fn url(self) -> (Url, CsrfToken) {
@@ -39,7 +29,7 @@ where
         self
     }
 
-    pub fn set_authorization_details(
+    pub fn set_authorization_details<AD: AuthorizationDetailsProfile>(
         mut self,
         authorization_details: Vec<AuthorizationDetail<AD>>,
     ) -> Result<Self, serde_json::Error> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -13,7 +13,7 @@ use crate::{
         credential_issuer::{CredentialIssuerMetadataDisplay, CredentialMetadata},
         AuthorizationServerMetadata, CredentialIssuerMetadata,
     },
-    profiles::{AuthorizationDetailsProfile, Profile},
+    profiles::Profile,
     pushed_authorization::PushedAuthorizationRequest,
     token,
     types::{BatchCredentialUrl, CredentialUrl, DeferredCredentialUrl, IssuerUrl, ParUrl},
@@ -117,13 +117,12 @@ where
         }
     }
 
-    pub fn pushed_authorization_request<S, AD>(
+    pub fn pushed_authorization_request<S>(
         &self,
         state_fn: S,
-    ) -> Result<PushedAuthorizationRequest<AD>, Error>
+    ) -> Result<PushedAuthorizationRequest, Error>
     where
         S: FnOnce() -> CsrfToken,
-        AD: AuthorizationDetailsProfile,
     {
         let Some(par_url) = self.par_auth_url.as_ref() else {
             return Err(Error::ParUnsupported);
@@ -141,10 +140,9 @@ where
         ))
     }
 
-    pub fn authorize_url<S, AD>(&self, state_fn: S) -> Result<AuthorizationRequest<AD>, Error>
+    pub fn authorize_url<S>(&self, state_fn: S) -> Result<AuthorizationRequest, Error>
     where
         S: FnOnce() -> CsrfToken,
-        AD: AuthorizationDetailsProfile,
     {
         let inner = self
             .inner

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,36 +1,21 @@
 pub mod profiles;
 
 pub mod metadata {
-    use openidconnect::core::{CoreJweContentEncryptionAlgorithm, CoreJweKeyManagementAlgorithm};
-
     use crate::metadata;
 
     use super::profiles::CoreProfilesConfiguration;
 
-    pub type CredentialIssuerMetadata = metadata::CredentialIssuerMetadata<
-        CoreProfilesConfiguration,
-        CoreJweContentEncryptionAlgorithm,
-        CoreJweKeyManagementAlgorithm,
-    >;
+    pub type CredentialIssuerMetadata =
+        metadata::CredentialIssuerMetadata<CoreProfilesConfiguration>;
 }
 
 pub mod credential {
-    use openidconnect::core::{CoreJweContentEncryptionAlgorithm, CoreJweKeyManagementAlgorithm};
-
     use crate::credential;
 
     use super::profiles::CoreProfilesRequest;
 
-    pub type Request = credential::Request<
-        CoreProfilesRequest,
-        CoreJweContentEncryptionAlgorithm,
-        CoreJweKeyManagementAlgorithm,
-    >;
-    pub type BatchRequest = credential::BatchRequest<
-        CoreProfilesRequest,
-        CoreJweContentEncryptionAlgorithm,
-        CoreJweKeyManagementAlgorithm,
-    >;
+    pub type Request = credential::Request<CoreProfilesRequest>;
+    pub type BatchRequest = credential::BatchRequest<CoreProfilesRequest>;
 }
 
 pub mod authorization {
@@ -43,25 +28,22 @@ pub mod authorization {
 }
 
 pub mod client {
-    use openidconnect::core::{CoreJweContentEncryptionAlgorithm, CoreJweKeyManagementAlgorithm};
 
     use crate::client;
 
     use super::profiles::CoreProfiles;
 
-    pub type Client = client::Client<
-        CoreProfiles,
-        CoreJweContentEncryptionAlgorithm,
-        CoreJweKeyManagementAlgorithm,
-    >;
+    pub type Client = client::Client<CoreProfiles>;
 }
 
 #[cfg(test)]
 mod test {
-    use openidconnect::IssuerUrl;
     use profiles::w3c::{self, CredentialDefinitionLD};
 
-    use crate::{credential_response_encryption::CredentialUrl, metadata::CredentialMetadata};
+    use crate::{
+        credential_response_encryption::CredentialUrl,
+        metadata::credential_issuer::CredentialMetadata, types::IssuerUrl,
+    };
 
     use super::*;
 
@@ -70,13 +52,13 @@ mod test {
         let metadata = super::metadata::CredentialIssuerMetadata::new(
             IssuerUrl::from_url("https://example.com".parse().unwrap()),
             CredentialUrl::from_url("https://example.com/credential".parse().unwrap()),
-            vec![CredentialMetadata::new(
-                "credential1".into(),
-                profiles::CoreProfilesConfiguration::JWTVC(w3c::jwt::Configuration::new(
-                    w3c::CredentialDefinition::new(vec!["type1".into()]),
-                )),
-            )],
-        );
+        )
+        .set_credential_configurations_supported(vec![CredentialMetadata::new(
+            "credential1".into(),
+            profiles::CoreProfilesConfiguration::JWTVC(w3c::jwt::Configuration::new(
+                w3c::CredentialDefinition::new(vec!["type1".into()]),
+            )),
+        )]);
         serde_json::to_vec(&metadata).unwrap();
     }
 
@@ -85,21 +67,21 @@ mod test {
         let metadata = super::metadata::CredentialIssuerMetadata::new(
             IssuerUrl::from_url("https://example.com".parse().unwrap()),
             CredentialUrl::from_url("https://example.com/credential".parse().unwrap()),
-            vec![CredentialMetadata::new(
-                "credential1".into(),
-                profiles::CoreProfilesConfiguration::LDVC(w3c::ldp::Configuration::new(
+        )
+        .set_credential_configurations_supported(vec![CredentialMetadata::new(
+            "credential1".into(),
+            profiles::CoreProfilesConfiguration::LDVC(w3c::ldp::Configuration::new(
+                vec![serde_json::Value::String(
+                    "http://example.com/context".into(),
+                )],
+                CredentialDefinitionLD::new(
+                    w3c::CredentialDefinition::new(vec!["type1".into()]),
                     vec![serde_json::Value::String(
                         "http://example.com/context".into(),
                     )],
-                    CredentialDefinitionLD::new(
-                        w3c::CredentialDefinition::new(vec!["type1".into()]),
-                        vec![serde_json::Value::String(
-                            "http://example.com/context".into(),
-                        )],
-                    ),
-                )),
-            )],
-        );
+                ),
+            )),
+        )]);
         serde_json::to_vec(&metadata).unwrap();
     }
 }

--- a/src/core/profiles/w3c/mod.rs
+++ b/src/core/profiles/w3c/mod.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::metadata::CredentialIssuerMetadataDisplay;
+use crate::metadata::credential_issuer::CredentialIssuerMetadataDisplay;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/credential_offer.rs
+++ b/src/credential_offer.rs
@@ -61,9 +61,9 @@ where
 #[skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct CredentialOfferGrants {
-    pub authorization_code: Option<AuthorizationCodeGrant>,
+    authorization_code: Option<AuthorizationCodeGrant>,
     #[serde(rename = "urn:ietf:params:oauth:grant-type:pre-authorized_code")]
-    pub pre_authorized_code: Option<PreAuthorizationCodeGrant>,
+    pre_authorized_code: Option<PreAuthorizationCodeGrant>,
 }
 impl CredentialOfferGrants {
     pub fn new(

--- a/src/credential_response_encryption.rs
+++ b/src/credential_response_encryption.rs
@@ -1,38 +1,30 @@
-#![allow(clippy::type_complexity)]
-
-use openidconnect::{JweContentEncryptionAlgorithm, JweKeyManagementAlgorithm};
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, skip_serializing_none};
 use ssi_jwk::JWK;
 
 pub use crate::types::{BatchCredentialUrl, CredentialUrl, DeferredCredentialUrl, ParUrl};
 
-#[serde_as]
-#[skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct CredentialResponseEncryptionMetadata<JE, JA>
-where
-    JE: JweContentEncryptionAlgorithm,
-    JA: JweKeyManagementAlgorithm + Clone,
-{
-    #[serde(bound = "JA: JweKeyManagementAlgorithm")]
-    alg_values_supported: Vec<JA>,
-    #[serde(bound = "JE: JweContentEncryptionAlgorithm")]
-    enc_values_supported: Vec<JE>,
+pub struct CredentialResponseEncryptionMetadata {
+    alg_values_supported: Vec<Alg>,
+    enc_values_supported: Vec<Enc>,
     encryption_required: bool,
 }
 
-#[serde_as]
-#[skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct CredentialResponseEncryption<JE, JA>
-where
-    JE: JweContentEncryptionAlgorithm,
-    JA: JweKeyManagementAlgorithm + Clone,
-{
+pub struct CredentialResponseEncryption {
     jwk: JWK,
-    #[serde(bound = "JA: JweKeyManagementAlgorithm")]
-    alg: JA,
-    #[serde(bound = "JE: JweContentEncryptionAlgorithm")]
-    enc: JE,
+    alg: Alg,
+    enc: Enc,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub enum Alg {
+    #[serde(untagged)]
+    Other(String),
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub enum Enc {
+    #[serde(untagged)]
+    Other(String),
 }

--- a/src/http_utils.rs
+++ b/src/http_utils.rs
@@ -1,3 +1,4 @@
+use anyhow::{bail, Result};
 use oauth2::{
     http::{
         header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE},
@@ -24,7 +25,7 @@ pub fn content_type_has_essence(content_type: &HeaderValue, expected_essence: &s
         .is_some()
 }
 
-pub fn check_content_type(headers: &HeaderMap, expected_content_type: &str) -> Result<(), String> {
+pub fn check_content_type(headers: &HeaderMap, expected_content_type: &str) -> Result<()> {
     headers
         .get(CONTENT_TYPE)
         .map_or(Ok(()), |content_type|
@@ -32,13 +33,11 @@ pub fn check_content_type(headers: &HeaderMap, expected_content_type: &str) -> R
             // may be followed by optional whitespace and/or a parameter (e.g., charset).
             // See https://tools.ietf.org/html/rfc7231#section-3.1.1.1.
             if !content_type_has_essence(content_type, expected_content_type) {
-                Err(
-                    format!(
+                    bail!(
                         "Unexpected response Content-Type: {:?}, should be `{}`",
                         content_type,
                         expected_content_type
                     )
-                )
             } else {
                 Ok(())
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,4 +17,4 @@ pub mod pushed_authorization;
 pub mod token;
 mod types;
 
-pub use openidconnect;
+pub use oauth2;

--- a/src/metadata/authorization_server.rs
+++ b/src/metadata/authorization_server.rs
@@ -1,0 +1,155 @@
+use anyhow::{bail, Result};
+use oauth2::{
+    AuthUrl, IntrospectionUrl, PkceCodeChallengeMethod, ResponseType, RevocationUrl, Scope,
+    TokenUrl,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value as Json};
+
+use crate::types::{IssuerUrl, JsonWebKeySetUrl, ParUrl, RegistrationUrl, ResponseMode};
+
+use super::MetadataDiscovery;
+
+/// Authorization Server Metadata according to
+/// [RFC8414](https://datatracker.ietf.org/doc/html/rfc8414) with the following modifications:
+/// * new metadata parameter `pre-authorized_grant_anonymous_access_supported` (as per OID4VP);
+/// * `response_types_supported` is now optional (as per OID4VP);
+/// * `token_endpoint` is no longer optional (OID4VP cannot be performed without the token
+///   endpoint);
+/// * additional parameters from
+///   [OAuth 2.0 Pushed Authorization Requests](https://datatracker.ietf.org/doc/html/rfc9126).
+/// * the following parameters from RFC 8414 are not yet implemented, but may still be accessed via
+///   `additional_fields`:
+///   * `token_endpoint_auth_methods_supported`
+///   * `token_endpoint_auth_signing_alg_values_supported`
+///   * `service_documentation`
+///   * `ui_locales_supported`
+///   * `op_policy_uri`
+///   * `op_tos_uri`
+///   * `revocation_endpoint_auth_methods_supported`
+///   * `revocation_endpoint_auth_singing_alg_values_supported`
+///   * `introspection_endpoint_auth_methods_supported`
+///   * `introspection_endpoint_auth_singing_alg_values_supported`
+///   
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct AuthorizationServerMetadata {
+    issuer: IssuerUrl,
+    authorization_endpoint: Option<AuthUrl>,
+    token_endpoint: TokenUrl,
+    jwks_uri: Option<JsonWebKeySetUrl>,
+    registration_endpoint: Option<RegistrationUrl>,
+    scopes_supported: Option<Vec<Scope>>,
+    response_types_supported: Option<Vec<ResponseType>>,
+    #[serde(default)]
+    response_modes_supported: ResponseModes,
+    #[serde(default)]
+    grant_types_supported: GrantTypesSupported,
+    revocation_endpoint: Option<RevocationUrl>,
+    introspection_endpoint: Option<IntrospectionUrl>,
+    code_challenge_methods_supported: Option<Vec<PkceCodeChallengeMethod>>,
+    #[serde(default, rename = "pre-authorized_grant_anonymous_access_supported")]
+    pre_authorized_grant_anonymous_access_supported: bool,
+    pushed_authorization_request_endpoint: Option<ParUrl>,
+    #[serde(default)]
+    require_pushed_authorization_requests: bool,
+    additional_fields: Map<String, Json>,
+}
+
+impl AuthorizationServerMetadata {
+    #[cfg(test)]
+    pub fn new(issuer: IssuerUrl, token_endpoint: TokenUrl) -> Self {
+        Self {
+            issuer,
+            authorization_endpoint: Default::default(),
+            token_endpoint,
+            jwks_uri: Default::default(),
+            registration_endpoint: Default::default(),
+            scopes_supported: Default::default(),
+            response_types_supported: Default::default(),
+            response_modes_supported: Default::default(),
+            grant_types_supported: Default::default(),
+            revocation_endpoint: Default::default(),
+            introspection_endpoint: Default::default(),
+            code_challenge_methods_supported: Default::default(),
+            pre_authorized_grant_anonymous_access_supported: false,
+            pushed_authorization_request_endpoint: Default::default(),
+            require_pushed_authorization_requests: Default::default(),
+            additional_fields: Default::default(),
+        }
+    }
+
+    field_getters_setters![
+        pub self [self] ["authorization server metadata value"] {
+            set_issuer -> issuer[IssuerUrl],
+            set_authorization_endpoint -> authorization_endpoint[Option<AuthUrl>],
+            set_token_endpoint -> token_endpoint[TokenUrl],
+            set_jwks_uri -> jwks_uri[Option<JsonWebKeySetUrl>],
+            set_registration_endpoint -> registration_endpoint[Option<RegistrationUrl>],
+            set_scopes_supported -> scopes_supported[Option<Vec<Scope>>],
+            set_response_types_supported -> response_types_supported[Option<Vec<ResponseType>>],
+            set_response_modes_supported -> response_modes_supported[ResponseModes],
+            set_grant_types_supported -> grant_types_supported[GrantTypesSupported],
+            set_revocation_endpoint -> revocation_endpoint[Option<RevocationUrl>],
+            set_introspection_endpoint -> introspection_endpoint[Option<IntrospectionUrl>],
+            set_code_challenge_methods_supported -> code_challenge_methods_supported[Option<Vec<PkceCodeChallengeMethod>>],
+            set_pre_authorized_grant_anonymous_access_supported -> pre_authorized_grant_anonymous_access_supported[bool],
+            set_pushed_authorization_request_endpoint -> pushed_authorization_request_endpoint[Option<ParUrl>],
+            set_require_pushed_authorization_requests -> require_pushed_authorization_requests[bool],
+        }
+    ];
+
+    pub fn additional_fields(&self) -> &Map<String, Json> {
+        &self.additional_fields
+    }
+
+    pub fn additional_fields_mut(&mut self) -> &mut Map<String, Json> {
+        &mut self.additional_fields
+    }
+}
+
+impl MetadataDiscovery for AuthorizationServerMetadata {
+    const METADATA_URL_SUFFIX: &'static str = ".well-known/oauth-authorization-server";
+
+    fn validate(&self, issuer: &IssuerUrl) -> Result<()> {
+        if self.issuer() != issuer {
+            bail!(
+                "unexpected issuer URI `{}` (expected `{}`)",
+                self.issuer().as_str(),
+                issuer.as_str()
+            )
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ResponseModes(pub Vec<ResponseMode>);
+
+impl Default for ResponseModes {
+    fn default() -> Self {
+        Self(vec![
+            ResponseMode::new("query".to_owned()),
+            ResponseMode::new("fragment".to_owned()),
+        ])
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct GrantTypesSupported(pub Vec<GrantType>);
+
+impl Default for GrantTypesSupported {
+    fn default() -> Self {
+        Self(vec![GrantType::AuthorizationCode, GrantType::Implicit])
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum GrantType {
+    AuthorizationCode,
+    Implicit,
+    #[serde(rename = "urn:ietf:params:oauth:grant-type:pre-authorized_code")]
+    PreAuthorizedCode,
+    #[serde(untagged)]
+    Extension(String),
+}

--- a/src/metadata/credential_issuer.rs
+++ b/src/metadata/credential_issuer.rs
@@ -1,56 +1,34 @@
-#![allow(clippy::type_complexity)]
-
-use oauth2::{
-    http::{self, header::ACCEPT, HeaderValue, Method, StatusCode},
-    AsyncHttpClient, AuthUrl, HttpRequest, HttpResponse, SyncHttpClient, TokenUrl,
-};
-use openidconnect::{
-    core::{
-        CoreAuthDisplay, CoreClaimName, CoreClaimType, CoreClientAuthMethod, CoreGrantType,
-        CoreJsonWebKey, CoreJweContentEncryptionAlgorithm, CoreJweKeyManagementAlgorithm,
-        CoreJwsSigningAlgorithm, CoreResponseMode, CoreResponseType, CoreSubjectIdentifierType,
-    },
-    AdditionalProviderMetadata, DiscoveryError, IssuerUrl, JsonWebKeySetUrl,
-    JweContentEncryptionAlgorithm, JweKeyManagementAlgorithm, LanguageTag, LogoUrl,
-    ProviderMetadata, ResponseTypes, Scope,
-};
+use anyhow::bail;
+use oauth2::Scope;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, skip_serializing_none, KeyValueMap};
-use std::future::Future;
-use tracing::{debug, info, warn};
 
 use crate::{
     credential_response_encryption::CredentialResponseEncryptionMetadata,
-    http_utils::{check_content_type, MIME_TYPE_JSON},
     profiles::CredentialConfigurationProfile,
     proof_of_possession::KeyProofTypesSupported,
-    types::ImageUrl,
+    types::{
+        BatchCredentialUrl, CredentialUrl, DeferredCredentialUrl, IssuerUrl, LanguageTag, LogoUri,
+        NotificationUrl,
+    },
 };
 
-pub use crate::types::{
-    BatchCredentialUrl, CredentialUrl, DeferredCredentialUrl, NotificationUrl, ParUrl,
-};
-
-const METADATA_URL_SUFFIX: &str = ".well-known/openid-credential-issuer";
-const AUTHORIZATION_METADATA_URL_SUFFIX: &str = ".well-known/oauth-authorization-server";
+use super::MetadataDiscovery;
 
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct CredentialIssuerMetadata<CM, JE, JA>
+pub struct CredentialIssuerMetadata<CM>
 where
     CM: CredentialConfigurationProfile,
-    JE: JweContentEncryptionAlgorithm,
-    JA: JweKeyManagementAlgorithm + Clone,
 {
     credential_issuer: IssuerUrl,
-    authorization_servers: Option<Vec<IssuerUrl>>, // Not sure this is the right type
+    authorization_servers: Option<Vec<IssuerUrl>>,
     credential_endpoint: CredentialUrl,
     batch_credential_endpoint: Option<BatchCredentialUrl>,
     deferred_credential_endpoint: Option<DeferredCredentialUrl>,
     notification_endpoint: Option<NotificationUrl>,
-    #[serde(bound = "JA: JweKeyManagementAlgorithm, JE: JweContentEncryptionAlgorithm")]
-    credential_response_encryption: Option<CredentialResponseEncryptionMetadata<JE, JA>>,
+    credential_response_encryption: Option<CredentialResponseEncryptionMetadata>,
     credential_identifiers_supported: Option<bool>,
     signed_metadata: Option<String>,
     display: Option<Vec<CredentialIssuerMetadataDisplay>>,
@@ -59,17 +37,29 @@ where
     credential_configurations_supported: Vec<CredentialMetadata<CM>>,
 }
 
-impl<CM, JE, JA> CredentialIssuerMetadata<CM, JE, JA>
+impl<CM> MetadataDiscovery for CredentialIssuerMetadata<CM>
 where
     CM: CredentialConfigurationProfile,
-    JE: JweContentEncryptionAlgorithm,
-    JA: JweKeyManagementAlgorithm + Clone,
 {
-    pub fn new(
-        credential_issuer: IssuerUrl,
-        credential_endpoint: CredentialUrl,
-        credential_configurations_supported: Vec<CredentialMetadata<CM>>,
-    ) -> Self {
+    const METADATA_URL_SUFFIX: &'static str = ".well-known/openid-credential-issuer";
+
+    fn validate(&self, issuer: &IssuerUrl) -> anyhow::Result<()> {
+        if self.credential_issuer() != issuer {
+            bail!(
+                "unexpected issuer URI `{}` (expected `{}`)",
+                self.credential_issuer().as_str(),
+                issuer.as_str()
+            )
+        }
+        Ok(())
+    }
+}
+
+impl<CM> CredentialIssuerMetadata<CM>
+where
+    CM: CredentialConfigurationProfile,
+{
+    pub fn new(credential_issuer: IssuerUrl, credential_endpoint: CredentialUrl) -> Self {
         Self {
             credential_issuer,
             authorization_servers: None,
@@ -81,128 +71,25 @@ where
             credential_identifiers_supported: None,
             signed_metadata: None,
             display: None,
-            credential_configurations_supported,
+            credential_configurations_supported: vec![],
         }
     }
 
     field_getters_setters![
-        pub self [self] ["issuer metadata value"] {
+        pub self [self] ["credential issuer metadata value"] {
             set_credential_issuer -> credential_issuer[IssuerUrl],
             set_authorization_servers -> authorization_servers[Option<Vec<IssuerUrl>>],
             set_credential_endpoint -> credential_endpoint[CredentialUrl],
             set_batch_credential_endpoint -> batch_credential_endpoint[Option<BatchCredentialUrl>],
             set_deferred_credential_endpoint -> deferred_credential_endpoint[Option<DeferredCredentialUrl>],
             set_notification_endpoint -> notification_endpoint[Option<NotificationUrl>],
-            set_credential_response_encryption -> credential_response_encryption[Option<CredentialResponseEncryptionMetadata<JE, JA>>],
+            set_credential_response_encryption -> credential_response_encryption[Option<CredentialResponseEncryptionMetadata>],
             set_credential_identifiers_supported -> credential_identifiers_supported[Option<bool>],
             set_signed_metadata -> signed_metadata[Option<String>],
             set_display -> display[Option<Vec<CredentialIssuerMetadataDisplay>>],
             set_credential_configurations_supported -> credential_configurations_supported[Vec<CredentialMetadata<CM>>],
         }
     ];
-
-    pub fn discover<C>(
-        issuer_url: &IssuerUrl,
-        http_client: &C,
-    ) -> Result<Self, DiscoveryError<<C as SyncHttpClient>::Error>>
-    where
-        C: SyncHttpClient,
-    {
-        let discovery_url = issuer_url
-            .join(METADATA_URL_SUFFIX)
-            .map_err(DiscoveryError::UrlParse)?;
-
-        http_client
-            .call(
-                Self::discovery_request(discovery_url.clone()).map_err(|err| {
-                    DiscoveryError::Other(format!("failed to prepare request: {err}"))
-                })?,
-            )
-            .map_err(DiscoveryError::Request)
-            .and_then(|http_response| {
-                Self::discovery_response(issuer_url, &discovery_url, http_response)
-            })
-    }
-
-    pub fn discover_async<'c, C>(
-        issuer_url: IssuerUrl,
-        http_client: &'c C,
-    ) -> impl Future<Output = Result<Self, DiscoveryError<<C as AsyncHttpClient<'c>>::Error>>> + 'c
-    where
-        Self: 'c,
-        C: AsyncHttpClient<'c>,
-    {
-        Box::pin(async move {
-            let discovery_url = issuer_url
-                .join(METADATA_URL_SUFFIX)
-                .map_err(DiscoveryError::UrlParse)?;
-
-            let provider_metadata = http_client
-                .call(
-                    Self::discovery_request(discovery_url.clone()).map_err(|err| {
-                        DiscoveryError::Other(format!("failed to prepare request: {err}"))
-                    })?,
-                )
-                .await
-                .map_err(DiscoveryError::Request)
-                .and_then(|http_response| {
-                    Self::discovery_response(&issuer_url, &discovery_url, http_response)
-                })?;
-            Ok(provider_metadata)
-        })
-    }
-
-    fn discovery_request(discovery_url: url::Url) -> Result<HttpRequest, http::Error> {
-        http::Request::builder()
-            .uri(discovery_url.to_string())
-            .method(Method::GET)
-            .header(ACCEPT, HeaderValue::from_static(MIME_TYPE_JSON))
-            .body(Vec::new())
-    }
-
-    fn discovery_response<RE>(
-        issuer_url: &IssuerUrl,
-        discovery_url: &url::Url,
-        discovery_response: HttpResponse,
-    ) -> Result<Self, DiscoveryError<RE>>
-    where
-        RE: std::error::Error + 'static,
-    {
-        if discovery_response.status() != StatusCode::OK {
-            return Err(DiscoveryError::Response(
-                discovery_response.status(),
-                discovery_response.body().to_owned(),
-                format!(
-                    "HTTP status code {} at {}",
-                    discovery_response.status(),
-                    discovery_url
-                ),
-            ));
-        }
-
-        check_content_type(discovery_response.headers(), MIME_TYPE_JSON).map_err(|err_msg| {
-            DiscoveryError::Response(
-                discovery_response.status(),
-                discovery_response.body().to_owned(),
-                err_msg,
-            )
-        })?;
-
-        let provider_metadata = serde_path_to_error::deserialize::<_, Self>(
-            &mut serde_json::Deserializer::from_slice(discovery_response.body()),
-        )
-        .map_err(DiscoveryError::Parse)?;
-
-        if provider_metadata.credential_issuer() != issuer_url {
-            Err(DiscoveryError::Validation(format!(
-                "unexpected issuer URI `{}` (expected `{}`)",
-                provider_metadata.credential_issuer().as_str(),
-                issuer_url.as_str()
-            )))
-        } else {
-            Ok(provider_metadata)
-        }
-    }
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -232,18 +119,18 @@ impl CredentialIssuerMetadataDisplay {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct MetadataDisplayLogo {
-    url: LogoUrl,
+    uri: LogoUri,
     alt_text: Option<String>,
 }
 
 impl MetadataDisplayLogo {
-    pub fn new(url: LogoUrl, alt_text: Option<String>) -> Self {
-        Self { url, alt_text }
+    pub fn new(uri: LogoUri, alt_text: Option<String>) -> Self {
+        Self { uri, alt_text }
     }
 
     field_getters_setters![
         pub self [self] ["metadata display logo value"] {
-            set_url -> url[LogoUrl],
+            set_url -> uri[LogoUri],
             set_alt_text -> alt_text[Option<String>],
         }
     ];
@@ -267,17 +154,6 @@ where
     #[serde(flatten)]
     additional_fields: CM,
 }
-
-// #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-// pub enum CredentialMetadataProfileWrapper<CM>
-// where
-//     CM: CredentialMetadataProfile,
-// {
-//     #[serde(flatten, bound = "CM: CredentialMetadataProfile")]
-//     Known(CM),
-//     #[serde(other)]
-//     Unknown,
-// }
 
 impl<CM> CredentialMetadata<CM>
 where
@@ -368,302 +244,19 @@ impl CredentialMetadataDisplay {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct MetadataBackgroundImage {
-    uri: ImageUrl,
+    uri: LogoUri,
 }
 
 impl MetadataBackgroundImage {
-    pub fn new(uri: ImageUrl) -> Self {
+    pub fn new(uri: LogoUri) -> Self {
         Self { uri }
     }
 
     field_getters_setters![
         pub self [self] ["metadata background image value"] {
-            set_uri -> uri[ImageUrl],
+            set_uri -> uri[LogoUri],
         }
     ];
-}
-
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
-pub struct AdditionalOAuthMetadata {
-    #[serde(rename = "pre-authorized_grant_anonymous_access_supported")]
-    pre_authorized_grant_anonymous_access_supported: Option<bool>,
-    pushed_authorization_request_endpoint: Option<ParUrl>,
-    require_pushed_authorization_requests: Option<bool>,
-}
-
-impl AdditionalOAuthMetadata {
-    pub fn set_pushed_authorization_request_endpoint(
-        mut self,
-        pushed_authorization_request_endpoint: Option<ParUrl>,
-    ) -> Self {
-        self.pushed_authorization_request_endpoint = pushed_authorization_request_endpoint;
-        self
-    }
-
-    pub fn set_require_pushed_authorization_requests(
-        mut self,
-        require_pushed_authorization_requests: Option<bool>,
-    ) -> Self {
-        self.require_pushed_authorization_requests = require_pushed_authorization_requests;
-        self
-    }
-}
-
-impl AdditionalProviderMetadata for AdditionalOAuthMetadata {}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct AuthorizationMetadata(
-    ProviderMetadata<
-        AdditionalOAuthMetadata,
-        CoreAuthDisplay,
-        CoreClientAuthMethod,
-        CoreClaimName,
-        CoreClaimType,
-        CoreGrantType,
-        CoreJweContentEncryptionAlgorithm,
-        CoreJweKeyManagementAlgorithm,
-        CoreJsonWebKey,
-        CoreResponseMode,
-        CoreResponseType,
-        CoreSubjectIdentifierType,
-    >,
-); // TODO, does a oid4vci specific authorization server need a JWKs, and signed JWTs (instead of just JWE), etc?
-
-impl AuthorizationMetadata {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        issuer: IssuerUrl,
-        authorization_endpoint: AuthUrl,
-        token_endpoint: TokenUrl,
-        jwks_uri: JsonWebKeySetUrl,
-        response_types_supported: Vec<ResponseTypes<CoreResponseType>>,
-        subject_types_supported: Vec<CoreSubjectIdentifierType>,
-        id_token_signing_alg_values_supported: Vec<CoreJwsSigningAlgorithm>,
-        additional_metadata: AdditionalOAuthMetadata,
-    ) -> Self {
-        Self(
-            ProviderMetadata::new(
-                issuer,
-                authorization_endpoint,
-                jwks_uri,
-                response_types_supported,
-                subject_types_supported,
-                id_token_signing_alg_values_supported,
-                additional_metadata,
-            )
-            .set_token_endpoint(Some(token_endpoint)),
-        )
-    }
-
-    fn discover_inner<C>(
-        issuer_url: &IssuerUrl,
-        http_client: &C,
-    ) -> Result<Self, DiscoveryError<<C as SyncHttpClient>::Error>>
-    where
-        C: SyncHttpClient,
-    {
-        debug!("Discovering {issuer_url}");
-        let discovery_url = issuer_url
-            .join(AUTHORIZATION_METADATA_URL_SUFFIX)
-            .map_err(DiscoveryError::UrlParse)?;
-
-        http_client
-            .call(
-                Self::discovery_request(discovery_url.clone()).map_err(|err| {
-                    DiscoveryError::Other(format!("failed to prepare request: {err}"))
-                })?,
-            )
-            .map_err(DiscoveryError::Request)
-            .and_then(|http_response| {
-                Self::discovery_response(issuer_url, &discovery_url, http_response)
-            })
-    }
-
-    pub fn discover<C, CM, JE, JA>(
-        credential_issuer_metadata: &CredentialIssuerMetadata<CM, JE, JA>,
-        grant_type: Option<CoreGrantType>,
-        http_client: &C,
-    ) -> Result<Self, DiscoveryError<<C as SyncHttpClient>::Error>>
-    where
-        C: SyncHttpClient,
-        CM: CredentialConfigurationProfile,
-        JE: JweContentEncryptionAlgorithm,
-        JA: JweKeyManagementAlgorithm + Clone,
-    {
-        if let Some(ref servers) = credential_issuer_metadata.authorization_servers {
-            for auth_server in servers {
-                let response = Self::discover_inner(auth_server, http_client);
-                match (response, grant_type.clone()) {
-                    (Ok(response), Some(grant_type)) => {
-                        let gts = match response.0.grant_types_supported() {
-                            Some(gts) => gts,
-                            None => {
-                                // https://openid.net/specs/openid-connect-discovery-1_0.html
-                                // If omitted, the default value is ["authorization_code", "implicit"].
-                                &vec![CoreGrantType::AuthorizationCode, CoreGrantType::Implicit]
-                            }
-                        };
-                        if gts.iter().any(|gt| *gt == grant_type) {
-                            return Ok(response.clone());
-                        } else {
-                            info!("Auth server not supporting grant type, trying the next one");
-                        }
-                    }
-                    (Ok(response), None) => {
-                        return Ok(response.clone());
-                    }
-                    (Err(e), _) => {
-                        warn!("Error fetching auth server metadata, trying the next one: {e:?}");
-                    }
-                }
-            }
-        }
-        Self::discover_inner(&credential_issuer_metadata.credential_issuer, http_client)
-    }
-
-    fn discover_async_inner<'c, C>(
-        issuer_url: &'c IssuerUrl,
-        http_client: &'c C,
-    ) -> impl Future<Output = Result<Self, DiscoveryError<<C as AsyncHttpClient<'c>>::Error>>> + 'c
-    where
-        Self: 'c,
-        C: AsyncHttpClient<'c>,
-    {
-        Box::pin(async move {
-            debug!("Discovering {issuer_url}");
-            let discovery_url = issuer_url
-                .join(AUTHORIZATION_METADATA_URL_SUFFIX)
-                .map_err(DiscoveryError::UrlParse)?;
-
-            http_client
-                .call(
-                    Self::discovery_request(discovery_url.clone()).map_err(|err| {
-                        DiscoveryError::Other(format!("failed to prepare request: {err}"))
-                    })?,
-                )
-                .await
-                .map_err(DiscoveryError::Request)
-                .and_then(|http_response| {
-                    Self::discovery_response(issuer_url, &discovery_url, http_response)
-                })
-        })
-    }
-
-    pub fn discover_async<'c, C, CM, JE, JA>(
-        credential_issuer_metadata: &'c CredentialIssuerMetadata<CM, JE, JA>,
-        grant_type: Option<CoreGrantType>,
-        http_client: &'c C,
-    ) -> impl Future<Output = Result<Self, DiscoveryError<<C as AsyncHttpClient<'c>>::Error>>> + 'c
-    where
-        Self: 'c,
-        C: AsyncHttpClient<'c>,
-        CM: CredentialConfigurationProfile,
-        JE: JweContentEncryptionAlgorithm,
-        JA: JweKeyManagementAlgorithm + Clone,
-    {
-        Box::pin(async move {
-            if let Some(ref servers) = credential_issuer_metadata.authorization_servers {
-                for auth_server in servers {
-                    let response = Self::discover_async_inner(auth_server, http_client).await;
-                    match (response, grant_type.clone()) {
-                        (Ok(response), Some(grant_type)) => {
-                            let gts = match response.0.grant_types_supported() {
-                                Some(gts) => gts,
-                                None => {
-                                    // https://openid.net/specs/openid-connect-discovery-1_0.html
-                                    // If omitted, the default value is ["authorization_code", "implicit"].
-                                    &vec![CoreGrantType::AuthorizationCode, CoreGrantType::Implicit]
-                                }
-                            };
-                            if gts.iter().any(|gt| *gt == grant_type) {
-                                return Ok(response.clone());
-                            } else {
-                                info!("Auth server not supporting grant type, trying the next one");
-                            }
-                        }
-                        (Ok(response), None) => {
-                            return Ok(response.clone());
-                        }
-                        (Err(e), _) => {
-                            warn!(
-                                "Error fetching auth server metadata, trying the next one: {e:?}"
-                            );
-                        }
-                    }
-                }
-            }
-            Self::discover_async_inner(&credential_issuer_metadata.credential_issuer, http_client)
-                .await
-        })
-    }
-
-    fn discovery_request(discovery_url: url::Url) -> Result<HttpRequest, http::Error> {
-        http::Request::builder()
-            .uri(discovery_url.to_string())
-            .method(Method::GET)
-            .header(ACCEPT, HeaderValue::from_static(MIME_TYPE_JSON))
-            .body(Vec::new())
-    }
-
-    fn discovery_response<RE>(
-        issuer_url: &IssuerUrl,
-        discovery_url: &url::Url,
-        discovery_response: HttpResponse,
-    ) -> Result<Self, DiscoveryError<RE>>
-    where
-        RE: std::error::Error + 'static,
-    {
-        if discovery_response.status() != StatusCode::OK {
-            return Err(DiscoveryError::Response(
-                discovery_response.status(),
-                discovery_response.body().to_owned(),
-                format!(
-                    "HTTP status code {} at {}",
-                    discovery_response.status(),
-                    discovery_url
-                ),
-            ));
-        }
-
-        check_content_type(discovery_response.headers(), MIME_TYPE_JSON).map_err(|err_msg| {
-            DiscoveryError::Response(
-                discovery_response.status(),
-                discovery_response.body().to_owned(),
-                err_msg,
-            )
-        })?;
-
-        let provider_metadata = serde_path_to_error::deserialize::<_, Self>(
-            &mut serde_json::Deserializer::from_slice(discovery_response.body()),
-        )
-        .map_err(DiscoveryError::Parse)?;
-
-        if provider_metadata.0.issuer() != issuer_url {
-            Err(DiscoveryError::Validation(format!(
-                "unexpected issuer URI `{}` (expected `{}`)",
-                provider_metadata.0.issuer().as_str(),
-                issuer_url.as_str()
-            )))
-        } else {
-            Ok(provider_metadata)
-        }
-    }
-
-    pub fn authorization_endpoint(&self) -> &AuthUrl {
-        self.0.authorization_endpoint()
-    }
-
-    pub fn pushed_authorization_endpoint(&self) -> Option<ParUrl> {
-        self.0
-            .additional_metadata()
-            .clone()
-            .pushed_authorization_request_endpoint
-    }
-
-    pub fn token_endpoint(&self) -> &TokenUrl {
-        // TODO find better way to avoid unwrap
-        self.0.token_endpoint().unwrap()
-    }
 }
 
 #[cfg(test)]
@@ -677,8 +270,6 @@ mod test {
     fn example_credential_issuer_metadata() {
         let _: CredentialIssuerMetadata<
             CoreProfilesConfiguration,
-            CoreJweContentEncryptionAlgorithm,
-            CoreJweKeyManagementAlgorithm,
         > = serde_json::from_value(json!({
             "credential_issuer": "https://credential-issuer.example.com",
             "authorization_servers": [ "https://server.example.com" ],
@@ -758,7 +349,7 @@ mod test {
                             "name": "University Credential",
                             "locale": "en-US",
                             "logo": {
-                                "url": "https://university.example.edu/public/logo.png",
+                                "uri": "https://university.example.edu/public/logo.png",
                                 "alt_text": "a square logo of a university"
                             },
                             "background_color": "#12107c",
@@ -829,7 +420,7 @@ mod test {
                     "name": "University Credential",
                     "locale": "en-US",
                     "logo": {
-                        "url": "https://exampleuniversity.com/public/logo.png",
+                        "uri": "https://exampleuniversity.com/public/logo.png",
                         "alt_text": "a square logo of a university"
                     },
                     "background_color": "#12107c",
@@ -903,7 +494,7 @@ mod test {
                     "name": "University Credential",
                     "locale": "en-US",
                     "logo": {
-                        "url": "https://exampleuniversity.com/public/logo.png",
+                        "uri": "https://exampleuniversity.com/public/logo.png",
                         "alt_text": "a square logo of a university"
                     },
                     "background_color": "#12107c",
@@ -934,7 +525,7 @@ mod test {
                     "name": "Mobile Driving License",
                     "locale": "en-US",
                     "logo": {
-                        "url": "https://examplestate.com/public/mdl.png",
+                        "uri": "https://examplestate.com/public/mdl.png",
                         "alt_text": "a square figure of a mobile driving license"
                     },
                     "background_color": "#12107c",
@@ -947,7 +538,7 @@ mod test {
                     "name": "在籍証明書",
                     "locale": "ja-JP",
                     "logo": {
-                        "url": "https://examplestate.com/public/mdl.png",
+                        "uri": "https://examplestate.com/public/mdl.png",
                         "alt_text": "大学のロゴ"
                     },
                     "background_color": "#12107c",

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -1,0 +1,100 @@
+#![allow(clippy::type_complexity)]
+
+use std::future::Future;
+
+use anyhow::{bail, Context, Result};
+use oauth2::{
+    http::{self, header::ACCEPT, HeaderValue, Method, StatusCode},
+    AsyncHttpClient, HttpRequest, HttpResponse, SyncHttpClient,
+};
+use serde::{de::DeserializeOwned, Serialize};
+use url::Url;
+
+use crate::{
+    http_utils::{check_content_type, MIME_TYPE_JSON},
+    types::IssuerUrl,
+};
+
+pub mod authorization_server;
+pub mod credential_issuer;
+
+pub use authorization_server::AuthorizationServerMetadata;
+pub use credential_issuer::CredentialIssuerMetadata;
+
+pub trait MetadataDiscovery: DeserializeOwned + Serialize {
+    const METADATA_URL_SUFFIX: &'static str;
+
+    fn validate(&self, issuer: &IssuerUrl) -> Result<()>;
+
+    fn discover<C>(issuer: &IssuerUrl, http_client: &C) -> Result<Self>
+    where
+        C: SyncHttpClient,
+        C::Error: Send + Sync,
+    {
+        let discovery_url = discovery_url::<Self>(issuer)?;
+
+        let discovery_request = discovery_request(&discovery_url)?;
+
+        let http_response = http_client.call(discovery_request)?;
+
+        discovery_response(issuer, &discovery_url, http_response)
+    }
+
+    fn discover_async<'c, C>(
+        issuer: &IssuerUrl,
+        http_client: &'c C,
+    ) -> impl Future<Output = Result<Self>>
+    where
+        C: AsyncHttpClient<'c>,
+        C::Error: Send + Sync,
+    {
+        Box::pin(async move {
+            let discovery_url = discovery_url::<Self>(issuer)?;
+
+            let discovery_request = discovery_request(&discovery_url)?;
+
+            let http_response = http_client.call(discovery_request).await?;
+
+            discovery_response(issuer, &discovery_url, http_response)
+        })
+    }
+}
+
+fn discovery_url<M: MetadataDiscovery>(issuer: &IssuerUrl) -> Result<Url> {
+    issuer
+        .join(M::METADATA_URL_SUFFIX)
+        .context("failed to construct metadata URL")
+}
+
+fn discovery_request(discovery_url: &Url) -> Result<HttpRequest> {
+    http::Request::builder()
+        .uri(discovery_url.to_string())
+        .method(Method::GET)
+        .header(ACCEPT, HeaderValue::from_static(MIME_TYPE_JSON))
+        .body(Vec::new())
+        .context("failed to prepare request")
+}
+
+fn discovery_response<M: MetadataDiscovery>(
+    issuer: &IssuerUrl,
+    discovery_url: &Url,
+    discovery_response: HttpResponse,
+) -> Result<M> {
+    if discovery_response.status() != StatusCode::OK {
+        bail!(
+            "HTTP status code {} at {}",
+            discovery_response.status(),
+            discovery_url
+        )
+    }
+
+    check_content_type(discovery_response.headers(), MIME_TYPE_JSON)?;
+
+    let metadata = serde_path_to_error::deserialize::<_, M>(
+        &mut serde_json::Deserializer::from_slice(discovery_response.body()),
+    )?;
+
+    metadata.validate(issuer)?;
+
+    Ok(metadata)
+}

--- a/src/proof_of_possession.rs
+++ b/src/proof_of_possession.rs
@@ -1,4 +1,3 @@
-use openidconnect::Nonce;
 use serde::{Deserialize, Serialize};
 use ssi_claims::{
     jws::{self, Header},
@@ -8,6 +7,8 @@ use ssi_dids_core::DIDURLBuf;
 use ssi_jwk::{Algorithm, JWKResolver, JWK};
 use time::{Duration, OffsetDateTime};
 use url::Url;
+
+use crate::types::Nonce;
 
 const JWS_TYPE: &str = "openid4vci-proof+jwt";
 

--- a/src/pushed_authorization.rs
+++ b/src/pushed_authorization.rs
@@ -1,11 +1,11 @@
-use std::future::Future;
+use std::{borrow::Cow, collections::HashMap, future::Future};
 
 use crate::{
-    authorization::AuthorizationDetail,
+    authorization::{AuthorizationDetail, AuthorizationRequest},
     credential::RequestError,
     http_utils::{content_type_has_essence, MIME_TYPE_FORM_URLENCODED, MIME_TYPE_JSON},
     profiles::AuthorizationDetailsProfile,
-    types::ParUrl,
+    types::{IssuerState, IssuerUrl, Nonce, ParUrl, UserHint},
 };
 use oauth2::{
     http::{
@@ -14,9 +14,8 @@ use oauth2::{
         HeaderValue, Method, StatusCode,
     },
     AsyncHttpClient, AuthUrl, ClientId, CsrfToken, HttpRequest, PkceCodeChallenge,
-    PkceCodeChallengeMethod, RedirectUrl,
+    PkceCodeChallengeMethod, RedirectUrl, SyncHttpClient,
 };
-use openidconnect::{core::CoreErrorResponseType, IssuerUrl, Nonce, StandardErrorResponse};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, skip_serializing_none};
 
@@ -40,12 +39,10 @@ impl ParRequestUri {
     }
 }
 
-pub type Error = StandardErrorResponse<CoreErrorResponseType>;
-
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct ParAuthParams {
+struct ParAuthParams {
     client_id: ClientId,
     state: CsrfToken,
     code_challenge: String,
@@ -58,25 +55,8 @@ pub struct ParAuthParams {
     wallet_issuer: Option<IssuerUrl>,
     user_hint: Option<String>,
     issuer_state: Option<CsrfToken>,
-}
-
-impl ParAuthParams {
-    field_getters_setters![
-        pub self [self] ["ParAuthParams value"] {
-            set_client_id -> client_id[ClientId],
-            set_state -> state[CsrfToken],
-            set_code_challenge -> code_challenge[String],
-            set_code_challenge_method -> code_challenge_method[PkceCodeChallengeMethod],
-            set_redirect_uri -> redirect_uri[RedirectUrl],
-            set_response_type -> response_type[Option<String>],
-            set_client_assertion -> client_assertion[Option<String>],
-            set_client_assertion_type -> client_assertion_type[Option<String>],
-            set_authorization_details -> authorization_details[Option<String>],
-            set_wallet_issuer -> wallet_issuer[Option<IssuerUrl>],
-            set_user_hint -> user_hint[Option<String>],
-            set_issuer_state -> issuer_state[Option<CsrfToken>],
-        }
-    ];
+    #[serde(flatten)]
+    additional_fields: HashMap<String, String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -89,13 +69,9 @@ pub struct PushedAuthorizationRequest<'a, AD>
 where
     AD: AuthorizationDetailsProfile,
 {
-    inner: oauth2::AuthorizationRequest<'a>, // TODO
+    inner: AuthorizationRequest<'a, AD>,
     par_auth_url: ParUrl,
     auth_url: AuthUrl,
-    authorization_details: Vec<AuthorizationDetail<AD>>,
-    wallet_issuer: Option<IssuerUrl>, // TODO SIOP related
-    user_hint: Option<String>,
-    issuer_state: Option<CsrfToken>,
 }
 
 impl<'a, AD> PushedAuthorizationRequest<'a, AD>
@@ -103,30 +79,50 @@ where
     AD: AuthorizationDetailsProfile,
 {
     pub(crate) fn new(
-        inner: oauth2::AuthorizationRequest<'a>,
+        inner: AuthorizationRequest<'a, AD>,
         par_auth_url: ParUrl,
         auth_url: AuthUrl,
-        authorization_details: Vec<AuthorizationDetail<AD>>,
-        wallet_issuer: Option<IssuerUrl>,
-        user_hint: Option<String>,
-        issuer_state: Option<CsrfToken>,
     ) -> Self {
         Self {
             inner,
             par_auth_url,
             auth_url,
-            authorization_details,
-            wallet_issuer,
-            user_hint,
-            issuer_state,
         }
+    }
+
+    pub fn request<C>(
+        self,
+        http_client: &C,
+    ) -> Result<(url::Url, CsrfToken), RequestError<<C as SyncHttpClient>::Error>>
+    where
+        C: SyncHttpClient,
+    {
+        let mut auth_url = self.auth_url.url().clone();
+
+        let (http_request, req_body, token) = self
+            .prepare_request()
+            .map_err(|err| RequestError::Other(format!("failed to prepare request: {err:?}")))?;
+
+        let http_response = http_client
+            .call(http_request)
+            .map_err(RequestError::Request)?;
+
+        let parsed_response = Self::parse_response(http_response)?;
+
+        auth_url
+            .query_pairs_mut()
+            .append_pair("request_uri", parsed_response.request_uri.get());
+
+        auth_url
+            .query_pairs_mut()
+            .append_pair("client_id", &req_body.client_id.to_string());
+
+        Ok((auth_url, token))
     }
 
     pub fn async_request<'c, C>(
         self,
         http_client: &'c C,
-        client_assertion_type: Option<String>,
-        client_assertion: Option<String>,
     ) -> impl Future<
         Output = Result<(url::Url, CsrfToken), RequestError<<C as AsyncHttpClient<'c>>::Error>>,
     > + 'c
@@ -138,43 +134,16 @@ where
         Box::pin(async move {
             let mut auth_url = self.auth_url.url().clone();
 
-            let (http_request, req_body, token) = self
-                .prepare_request(client_assertion, client_assertion_type)
-                .map_err(|err| {
-                    RequestError::Other(format!("failed to prepare request: {err:?}"))
-                })?;
+            let (http_request, req_body, token) = self.prepare_request().map_err(|err| {
+                RequestError::Other(format!("failed to prepare request: {err:?}"))
+            })?;
 
             let http_response = http_client
                 .call(http_request)
                 .await
                 .map_err(RequestError::Request)?;
 
-            if http_response.status() != StatusCode::OK {
-                return Err(RequestError::Response(
-                    http_response.status(),
-                    http_response.body().to_owned(),
-                    "unexpected HTTP status code".to_string(),
-                ));
-            }
-
-            let parsed_response: PushedAuthorizationResponse = match http_response
-                .headers()
-                .get(CONTENT_TYPE)
-                .map(ToOwned::to_owned)
-                .unwrap_or_else(|| HeaderValue::from_static(MIME_TYPE_JSON))
-            {
-                ref content_type if content_type_has_essence(content_type, MIME_TYPE_JSON) => {
-                    serde_path_to_error::deserialize(&mut serde_json::Deserializer::from_slice(
-                        &http_response.body().to_owned(),
-                    ))
-                    .map_err(RequestError::Parse)
-                }
-                ref content_type => Err(RequestError::Response(
-                    http_response.status(),
-                    http_response.body().to_owned(),
-                    format!("unexpected response Content-Type: `{:?}`", content_type),
-                )),
-            }?;
+            let parsed_response = Self::parse_response(http_response)?;
 
             auth_url
                 .query_pairs_mut()
@@ -188,29 +157,13 @@ where
         })
     }
 
-    pub fn prepare_request(
+    fn prepare_request(
         self,
-        client_assertion: Option<String>,
-        client_assertion_type: Option<String>,
     ) -> Result<(HttpRequest, ParAuthParams, CsrfToken), RequestError<http::Error>> {
         let (url, token) = self.inner.url();
 
-        let body = serde_urlencoded::from_str::<ParAuthParams>(url.clone().as_str())
-            .map_err(|_| RequestError::Other("failed parsing url".to_string()))?
-            .set_client_assertion_type(client_assertion_type.clone())
-            .set_client_assertion(client_assertion.clone())
-            .set_authorization_details(Some(
-                serde_json::to_string::<Vec<AuthorizationDetail<AD>>>(&self.authorization_details)
-                    .map_err(|e| {
-                        RequestError::Other(format!(
-                            "unable to serialize authorization_details: {}",
-                            e
-                        ))
-                    })?,
-            ))
-            .set_wallet_issuer(self.wallet_issuer)
-            .set_user_hint(self.user_hint)
-            .set_issuer_state(self.issuer_state);
+        let body = serde_urlencoded::from_str::<ParAuthParams>(url.query().unwrap_or_default())
+            .map_err(|_| RequestError::Other("failed parsing url".to_string()))?;
 
         let request = http::Request::builder()
             .uri(self.par_auth_url.to_string())
@@ -232,15 +185,81 @@ where
         Ok((request, body, token))
     }
 
+    fn parse_response<RE: std::error::Error>(
+        http_response: http::Response<Vec<u8>>,
+    ) -> Result<PushedAuthorizationResponse, RequestError<RE>> {
+        if http_response.status() != StatusCode::OK {
+            return Err(RequestError::Response(
+                http_response.status(),
+                http_response.body().to_owned(),
+                "unexpected HTTP status code".to_string(),
+            ));
+        }
+
+        match http_response
+            .headers()
+            .get(CONTENT_TYPE)
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| HeaderValue::from_static(MIME_TYPE_JSON))
+        {
+            ref content_type if content_type_has_essence(content_type, MIME_TYPE_JSON) => {
+                serde_path_to_error::deserialize(&mut serde_json::Deserializer::from_slice(
+                    &http_response.body().to_owned(),
+                ))
+                .map_err(RequestError::Parse)
+            }
+            ref content_type => Err(RequestError::Response(
+                http_response.status(),
+                http_response.body().to_owned(),
+                format!("unexpected response Content-Type: `{:?}`", content_type),
+            )),
+        }
+    }
+
     pub fn set_pkce_challenge(mut self, pkce_code_challenge: PkceCodeChallenge) -> Self {
         self.inner = self.inner.set_pkce_challenge(pkce_code_challenge);
         self
     }
+
     pub fn set_authorization_details(
         mut self,
         authorization_details: Vec<AuthorizationDetail<AD>>,
-    ) -> Self {
-        self.authorization_details = authorization_details;
+    ) -> Result<Self, serde_json::Error> {
+        self.inner = self
+            .inner
+            .set_authorization_details(authorization_details)?;
+        Ok(self)
+    }
+
+    pub fn set_issuer_state(mut self, issuer_state: &'a IssuerState) -> Self {
+        self.inner = self.inner.set_issuer_state(issuer_state);
+        self
+    }
+
+    pub fn set_user_hint(mut self, user_hint: &'a UserHint) -> Self {
+        self.inner = self.inner.set_user_hint(user_hint);
+        self
+    }
+
+    pub fn set_wallet_issuer(mut self, wallet_issuer: &'a IssuerUrl) -> Self {
+        self.inner = self.inner.set_wallet_issuer(wallet_issuer);
+        self
+    }
+
+    pub fn set_client_assertion(self, client_assertion: String) -> Self {
+        self.add_extra_param("client_assertion", client_assertion)
+    }
+
+    pub fn set_client_assertion_type(self, client_assertion_type: String) -> Self {
+        self.add_extra_param("client_assertion_type", client_assertion_type)
+    }
+
+    pub fn add_extra_param<N, V>(mut self, name: N, value: V) -> Self
+    where
+        N: Into<Cow<'a, str>>,
+        V: Into<Cow<'a, str>>,
+    {
+        self.inner = self.inner.add_extra_param(name, value);
         self
     }
 }
@@ -251,7 +270,11 @@ mod test {
     use oauth2::{AuthUrl, ClientId, PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, TokenUrl};
     use serde_json::json;
 
-    use crate::{core::profiles::CoreProfilesAuthorizationDetails, metadata::CredentialUrl};
+    use crate::{
+        core::{metadata::CredentialIssuerMetadata, profiles::CoreProfilesAuthorizationDetails},
+        metadata::AuthorizationServerMetadata,
+        types::CredentialUrl,
+    };
 
     use super::*;
 
@@ -263,18 +286,33 @@ mod test {
             "code_challenge": "MYdqq2Vt_ZLMAWpXXsjGIrlxrCF2e4ZP4SxDf7cm_tg",
             "code_challenge_method": "S256",
             "redirect_uri": "https://client.example.org/cb",
-
+            "response_type": "code",
             "authorization_details": "[]",
         });
 
-        let client = crate::core::client::Client::new(
-            ClientId::new("s6BhdRkqt3".to_string()),
-            IssuerUrl::new("https://server.example.com".into()).unwrap(),
+        let issuer = IssuerUrl::new("https://server.example.com".into()).unwrap();
+
+        let credential_issuer_metadata = CredentialIssuerMetadata::new(
+            issuer.clone(),
             CredentialUrl::new("https://server.example.com/credential".into()).unwrap(),
-            AuthUrl::new("https://server.example.com/authorize".into()).unwrap(),
-            Some(ParUrl::new("https://server.example.com/as/par".into()).unwrap()),
+        );
+
+        let authorization_server_metadata = AuthorizationServerMetadata::new(
+            issuer,
             TokenUrl::new("https://server.example.com/token".into()).unwrap(),
+        )
+        .set_authorization_endpoint(Some(
+            AuthUrl::new("https://server.example.com/authorize".into()).unwrap(),
+        ))
+        .set_pushed_authorization_request_endpoint(Some(
+            ParUrl::new("https://server.example.com/as/par".into()).unwrap(),
+        ));
+
+        let client = crate::core::client::Client::from_issuer_metadata(
+            ClientId::new("s6BhdRkqt3".to_string()),
             RedirectUrl::new("https://client.example.org/cb".into()).unwrap(),
+            credential_issuer_metadata,
+            authorization_server_metadata,
         );
 
         let pkce_verifier =
@@ -286,7 +324,9 @@ mod test {
             .pushed_authorization_request::<_, CoreProfilesAuthorizationDetails>(move || state)
             .unwrap()
             .set_pkce_challenge(pkce_challenge)
-            .prepare_request(None, None)
+            .set_authorization_details(vec![])
+            .unwrap()
+            .prepare_request()
             .unwrap();
         assert_json_eq!(expected_body, body);
     }

--- a/src/pushed_authorization.rs
+++ b/src/pushed_authorization.rs
@@ -65,21 +65,15 @@ pub struct PushedAuthorizationResponse {
     pub expires_in: u64,
 }
 
-pub struct PushedAuthorizationRequest<'a, AD>
-where
-    AD: AuthorizationDetailsProfile,
-{
-    inner: AuthorizationRequest<'a, AD>,
+pub struct PushedAuthorizationRequest<'a> {
+    inner: AuthorizationRequest<'a>,
     par_auth_url: ParUrl,
     auth_url: AuthUrl,
 }
 
-impl<'a, AD> PushedAuthorizationRequest<'a, AD>
-where
-    AD: AuthorizationDetailsProfile,
-{
+impl<'a> PushedAuthorizationRequest<'a> {
     pub(crate) fn new(
-        inner: AuthorizationRequest<'a, AD>,
+        inner: AuthorizationRequest<'a>,
         par_auth_url: ParUrl,
         auth_url: AuthUrl,
     ) -> Self {
@@ -129,7 +123,6 @@ where
     where
         'a: 'c,
         C: AsyncHttpClient<'c>,
-        AD: 'c,
     {
         Box::pin(async move {
             let mut auth_url = self.auth_url.url().clone();
@@ -221,7 +214,7 @@ where
         self
     }
 
-    pub fn set_authorization_details(
+    pub fn set_authorization_details<AD: AuthorizationDetailsProfile>(
         mut self,
         authorization_details: Vec<AuthorizationDetail<AD>>,
     ) -> Result<Self, serde_json::Error> {
@@ -321,10 +314,10 @@ mod test {
         let state = CsrfToken::new("state".into());
 
         let (_, body, _) = client
-            .pushed_authorization_request::<_, CoreProfilesAuthorizationDetails>(move || state)
+            .pushed_authorization_request(move || state)
             .unwrap()
             .set_pkce_challenge(pkce_challenge)
-            .set_authorization_details(vec![])
+            .set_authorization_details::<CoreProfilesAuthorizationDetails>(vec![])
             .unwrap()
             .prepare_request()
             .unwrap();


### PR DESCRIPTION
Removed dependency on openidconnect due to spec incompatibility.

Refactoring:
* defined MetadataDiscovery trait to share the common metadata resolution code for `authorization_server_metadata` and `credential_issuer_metadata`
* API changes to `Client`, authorization request and PAR to handle request parameters more consistently

Fixed a couple of bugs:
* `response_type` no longer dropped in PAR request builder
* `uri` instead of `url` used in credential metadata -> logo [[spec source]](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-10.2.3-2.9.2.3.2.1)
