### PR TITLE
Issuer conformance examples (OID4VCI 1.0 + FAPI2/HAIP)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ hyper-util = "0.1.19"
 http-body-util = "0.1.3"
 dashmap = "6.1.0"
 anyhow = "1.0.86"
+sha2 = "0.10"
 
 [[example]]
 name = "wallet-oid4vci-conformance"

--- a/examples/issuer-conformance/.gitignore
+++ b/examples/issuer-conformance/.gitignore
@@ -1,0 +1,7 @@
+crypto/attester
+crypto/ca
+crypto/issuer
+crypto/key-attestation
+crypto/wallet
+crypto/wallet2
+test.json

--- a/examples/issuer-conformance/README.md
+++ b/examples/issuer-conformance/README.md
@@ -1,0 +1,175 @@
+# Issuer Conformance
+
+An OID4VCI 1.0 **Credential Issuer** + OAuth2 Authorization Server (with PAR),
+driven by the OpenID Foundation conformance suite acting as the **wallet** (the
+mirror image of [`../wallet-conformance/`](../wallet-conformance/), where the
+suite is the issuer).
+
+The single `issuer-conformance` example (`main.rs` + modules in this folder)
+serves both the `oid4vci-1_0-issuer-*` and `fapi2-security-profile-final-*` test
+plans — they exercise the same server.
+
+## Prerequisites
+
+You'll need the following:
+
+- `step-cli` (called `step` on macOS).
+- `jq`
+- `sponge`
+
+## Setup
+
+1. Go to the OpenID Foundation conformance suite website:
+
+<https://demo.certification.openid.net/>
+
+2. Create a new test plan and select an **OID4VCI issuer** test plan.
+3. Run `setup.sh` to generate the cryptographic material and the `test.json`
+   configuration:
+
+   ```bash
+   examples/issuer-conformance/setup.sh
+   ```
+
+4. Copy the generated `test.json` into the `JSON` tab of the "Configure Test"
+   section, then create the test plan.
+
+## Running
+
+The conformance suite runs in the cloud, so it must be able to reach this
+issuer. Expose it with a tunnel (e.g. ngrok) and pass the public URL via
+`--public-url` — it becomes the Credential Issuer identifier and must match
+`vci.credential_issuer_url` in `test.json`.
+
+```bash
+# 1. Start a tunnel to the local port (default 3000):
+ngrok http 3000
+
+# 2. Generate test.json with that public URL baked into vci.credential_issuer_url:
+examples/issuer-conformance/setup.sh --public-url https://YOUR_NGROK_URL.ngrok-free.app
+
+# 3. Run the issuer:
+cargo run --example issuer-conformance --features axum -- \
+  --public-url https://65ad-2001-1284-f50e-21d4-1dfd-7ac1-841c-fd23.ngrok-free.app
+```
+
+Health check: `curl https://YOUR_NGROK_URL.ngrok-free.app/health` (expects `200`).
+
+The one running server supports every flow without a restart:
+
+- **Wallet-initiated** and **Pre-Authorized Code** flows are driven entirely by
+  the wallet through the HTTP endpoints — nothing else to do.
+- **Issuer-initiated** flow: the server prompts on the terminal for the wallet's
+  `credential_offer_endpoint` (the value the conformance test exports). Paste it
+  and the server builds and delivers a Credential Offer to it. Other flows just
+  ignore the prompt.
+
+```
+credential_offer_endpoint> https://demo.certification.openid.net/test/a/<alias>/credential_offer
+Delivered Credential Offer to https://.../credential_offer (HTTP 200 OK).
+```
+
+| Flag                 | Description                                                                                                                                                                                    |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-P, --public-url`   | Public URL the suite reaches the issuer at (the tunnel URL).                                                                                                                                   |
+| `-p, --port`         | Local listening port (default `3000`).                                                                                                                                                         |
+| `-k, --issuer-jwk`   | Credential signing JWK (default `crypto/issuer/jwk.json`, has `x5c`).                                                                                                                          |
+| `-a, --attester-jwk` | Trusted Client Attester public JWK (default `crypto/attester/jwk.pub.json`).                                                                                                                   |
+| `-r, --redirect-uri` | Registered client redirect URI(s); repeatable. When set, PAR rejects any other `redirect_uri`. Use the suite's callback (e.g. `https://www.certification.openid.net/test/a/<alias>/callback`). |
+
+## Configuration fields
+
+`setup.sh` fills the fields derived from the generated cryptographic material;
+the issuer-server-dependent `vci.*` fields are left as placeholders for you to
+edit in `test.json` before uploading.
+
+| `test.json` key                           | Filled by `setup.sh` from            | Notes                                                                                   |
+| ----------------------------------------- | ------------------------------------ | --------------------------------------------------------------------------------------- |
+| `credential.trust_anchor_pem`             | `ca/cert.pem`                        | Credential Trust Anchor                                                                 |
+| `credential.status_list_trust_anchor_pem` | `ca/cert.pem`                        | Status List Trust Anchor                                                                |
+| `client.client_id`                        | `wallet/did`                         |                                                                                         |
+| `client_attestation.attester_jwks`        | `attester/jwk.pub.json`              | wrapped as `{ "keys": [ … ] }`                                                          |
+| `client_attestation.issuer`               | `attester/did`                       | Client Attestation Issuer                                                               |
+| `client_attestation.key_attestation_jwks` | `key-attestation/jwk.pub.json`       | wrapped as `{ "keys": [ … ] }`                                                          |
+| `vci.credential_issuer_url`               | `--public-url` (or edit manually)    | public URL of your running issuer                                                       |
+| `vci.credential_configuration_id`         | — (preset `eu.europa.ec.eudi.pid.1`) | edit to match your issuer's config                                                      |
+| `vci.credential_proof_type_hint`          | — (optional, empty)                  | empty → suite uses the first proof type in the credential config                        |
+| `vci.authorization_server`                | `--public-url` (issuer is the AS)    | the AS the suite selects; must be listed in the issuer metadata `authorization_servers` |
+| `client2.client_id`                       | `wallet2/did`                        | second client identity (e.g. happy-flow-multiple-clients)                               |
+
+> The issuer's Credential **signing** key (`issuer/jwk.json`, with its `x5c`
+> chaining to `ca/cert.pem`) is loaded by the issuer server itself, not put in
+> `test.json`; the suite only needs the trust anchor (`ca/cert.pem`).
+
+## Tests requiring TLS cipher configuration (BCP 195)
+
+A few tests assert the TLS layer itself, not the protocol. FAPI2 §5.2.2
+(BCP 195 / RFC 9325) requires the server to accept **only** the recommended
+TLS 1.2 cipher suites:
+
+```
+ECDHE-ECDSA-AES128-GCM-SHA256   ECDHE-ECDSA-AES256-GCM-SHA384
+ECDHE-RSA-AES128-GCM-SHA256     ECDHE-RSA-AES256-GCM-SHA384
+DHE-RSA-AES128-GCM-SHA256       DHE-RSA-AES256-GCM-SHA384
+```
+
+(plus the TLS 1.3 suites). These tests assert on whatever terminates TLS at the
+public `:443` endpoint, and all fail on the same assertion,
+`RequireOnlyBCP195RecommendedCiphersForTLS12`:
+
+- `oid4vci-1_0-issuer-happy-flow-additional-requests`
+- `fapi2-security-profile-final-happy-flow`
+- `fapi2-security-profile-final-ensure-holder-of-key-required`
+
+This issuer speaks **plain HTTP** and never terminates TLS, so the negotiated
+cipher is entirely the public TLS terminator's. A plain `ngrok http` tunnel
+terminates TLS at ngrok's edge with ciphers you cannot restrict, so these tests
+fail on `RequireOnlyBCP195RecommendedCiphersForTLS12` even though every protocol
+assertion passes. The conformance suite **cannot produce a certification package
+while these are FAILED**, so they must be made to pass — a reviewer note does
+not unblock the package for a `FAILED`/`INTERRUPTED` test.
+
+To pass, terminate TLS yourself with a BCP 195-compliant configuration and a
+publicly trusted certificate for your own domain, exposed through a **pass-through**
+tunnel (raw TCP — e.g. `ngrok tls`, or self-hosted `frp`/`rathole`/`sish`) or a
+public IP, so your terminator — not the tunnel — performs the handshake.
+
+Example nginx in front of the issuer (`127.0.0.1:3000`):
+
+```nginx
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name issuer.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/issuer.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/issuer.example.com/privkey.pem;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    # Offer only ECDHE+AES-GCM (a subset of the permitted list, so no dhparam
+    # is needed); any non-permitted cipher the suite offers is then refused.
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers on;
+    ssl_ecdh_curve X25519:prime256v1:secp384r1;
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    }
+}
+```
+
+Then run with `--public-url https://issuer.example.com` and set
+`vci.credential_issuer_url` to the same. Only the HTTPS certificate is tied to
+the domain; the OID4VCI signing/attester material under `crypto/` is
+domain-independent and does **not** need regenerating. Verify before running the
+plan:
+
+```bash
+# A non-permitted cipher must be refused:
+openssl s_client -connect issuer.example.com:443 -cipher 'AES128-SHA' </dev/null
+# Enumerate what is actually accepted:
+nmap --script ssl-enum-ciphers -p 443 issuer.example.com
+```

--- a/examples/issuer-conformance/config.rs
+++ b/examples/issuer-conformance/config.rs
@@ -1,0 +1,382 @@
+use std::{
+    collections::HashMap,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use base64::Engine as _;
+use indexmap::IndexMap;
+use iref::UriBuf;
+use oid4vci::{
+    authorization::{
+        authorization_details::CredentialAuthorizationDetailsResponse,
+        server::Oid4vciAuthorizationServerMetadata,
+    },
+    issuer::{
+        metadata::{
+            CredentialConfiguration, CredentialDisplay, CredentialIssuerDisplay,
+            CryptographicBindingMethod, KeyProofTypesSupported,
+        },
+        CredentialIssuerMetadata,
+    },
+    profile::{dc_sd_jwt::DcSdJwtFormatMetadata, StandardCredentialFormatMetadata},
+};
+use open_auth2::{
+    ext::pkce::PkceCodeChallengeMethod, server::metadata::GrantType, ClientId, ScopeBuf,
+};
+use serde::Deserialize;
+use serde_json::json;
+use ssi::jwk::Algorithm;
+use ssi::{claims::jws::JwsSigner, JWK};
+
+/// Default credential configuration id (matches the conformance suite default).
+pub const DEFAULT_CREDENTIAL_CONFIGURATION_ID: &str = "eu.europa.ec.eudi.pid.1";
+
+/// Server configuration.
+#[derive(Deserialize)]
+pub struct Config {
+    /// Listening port.
+    pub port: u32,
+
+    /// Public URL the issuer is reachable at (e.g. the ngrok URL). Used as the
+    /// Credential Issuer identifier and to build all advertised endpoints.
+    #[serde(skip)]
+    pub public_url: Option<UriBuf>,
+
+    /// Enable the Pushed Authorization Request Endpoint.
+    #[serde(default)]
+    pub par: bool,
+
+    /// Enable Pre-Authorized Codes.
+    #[serde(default)]
+    pub pre_auth: bool,
+
+    /// Enable Credential Offers by reference.
+    #[serde(default)]
+    pub by_ref: bool,
+
+    /// Transaction Code for Pre-Authorized Codes.
+    #[serde(default)]
+    pub tx_code: Option<String>,
+
+    /// Authorization Server metadata override.
+    pub authorization_server_metadata: Option<Oid4vciAuthorizationServerMetadata>,
+
+    /// Registered client redirect URIs. When non-empty, an authorization
+    /// request's `redirect_uri` must be one of these or it is rejected
+    /// (FAPI2 §5.3.1.1 / RFC 6749 §3.1.2.3). Empty accepts any.
+    #[serde(default)]
+    pub registered_redirect_uris: Vec<UriBuf>,
+
+    /// Require an interactive consent step at the Authorization Endpoint instead
+    /// of auto-approving. When set, a valid pushed request renders an
+    /// approve/deny page rather than redirecting immediately; the `request_uri`
+    /// is consumed only once the user decides. Needed for the FAPI2 tests that
+    /// require the user to deny consent (`access_denied`, RFC 6749 §4.1.2.1) or
+    /// to reuse a `request_uri` before authentication completes.
+    #[serde(default)]
+    pub manual_consent: bool,
+
+    /// Credential configurations.
+    pub credential_configurations: HashMap<String, CredentialConfigurationConfig>,
+}
+
+impl Config {
+    /// Builds a conformance configuration reachable at `public_url`, with PAR
+    /// enabled and a default `eu.europa.ec.eudi.pid.1` SD-JWT VC credential.
+    pub fn new(public_url: UriBuf, port: u32, registered_redirect_uris: Vec<UriBuf>) -> Self {
+        let mut credential_configurations = HashMap::new();
+        credential_configurations.insert(
+            DEFAULT_CREDENTIAL_CONFIGURATION_ID.to_owned(),
+            CredentialConfigurationConfig {
+                scope: ScopeBuf::new(DEFAULT_CREDENTIAL_CONFIGURATION_ID.to_owned()).ok(),
+                display: vec![],
+                credentials: HashMap::from([(
+                    "pid".to_owned(),
+                    json!({
+                        "given_name": "Erika",
+                        "family_name": "Mustermann",
+                        "birthdate": "1963-08-12"
+                    }),
+                )]),
+                format: StandardCredentialFormatMetadata::DcSdJwt(DcSdJwtFormatMetadata {
+                    vct: DEFAULT_CREDENTIAL_CONFIGURATION_ID.to_owned(),
+                }),
+            },
+        );
+
+        Self {
+            port,
+            public_url: Some(public_url),
+            par: true,
+            pre_auth: false,
+            by_ref: false,
+            tx_code: None,
+            authorization_server_metadata: None,
+            registered_redirect_uris,
+            manual_consent: false,
+            credential_configurations,
+        }
+    }
+
+    /// Authorization Endpoint URL.
+    fn authorize_endpoint(&self) -> UriBuf {
+        UriBuf::new(format!("{}/authorize", self.credential_issuer()).into_bytes()).unwrap()
+    }
+
+    /// Token Endpoint URL.
+    fn token_endpoint(&self) -> UriBuf {
+        UriBuf::new(format!("{}/token", self.credential_issuer()).into_bytes()).unwrap()
+    }
+
+    /// Pushed Authorization Request Endpoint URL.
+    fn par_endpoint(&self) -> UriBuf {
+        UriBuf::new(format!("{}/par", self.credential_issuer()).into_bytes()).unwrap()
+    }
+
+    /// Default authorization server metadata.
+    pub fn default_authorization_server_metadata(&self) -> Oid4vciAuthorizationServerMetadata {
+        let mut metadata: Oid4vciAuthorizationServerMetadata =
+            Oid4vciAuthorizationServerMetadata::new(self.credential_issuer())
+                .with_authorization_endpoint(self.authorize_endpoint())
+                .with_token_endpoint(self.token_endpoint());
+
+        // FAPI2 / HAIP required Authorization Server metadata.
+        metadata.response_types_supported = Some(vec!["code".to_owned()]);
+        // FAPI2 forbids the implicit grant; advertise only authorization_code.
+        metadata.grant_types_supported = vec![GrantType::AuthorizationCode];
+        metadata.code_challenge_methods_supported = Some(vec![PkceCodeChallengeMethod::S256]);
+        // RFC 9207 / FAPI2 §5.3.2.2: we set the `iss` parameter in the
+        // authorization response, so advertise support for it.
+        metadata.authorization_response_iss_parameter_supported = Some(true);
+        // Attestation-Based Client Authentication (HAIP §4.3): advertise the
+        // `attest_jwt_client_auth` token endpoint auth method and the JWS algs
+        // supported for the Client Attestation JWT (ATCA-07 §13.3).
+        metadata.token_endpoint_auth_methods_supported =
+            Some(vec!["attest_jwt_client_auth".to_owned()]);
+        metadata
+            .extra
+            .client_attestation
+            .client_attestation_signing_alg_values_supported = vec![Algorithm::ES256];
+        metadata
+            .extra
+            .client_attestation
+            .client_attestation_pop_signing_alg_values_supported = vec![Algorithm::ES256];
+        metadata.scopes_supported = Some(
+            self.credential_configurations
+                .values()
+                .filter_map(|c| c.scope.clone())
+                .collect(),
+        );
+        metadata.extra.dpop.dpop_signing_alg_values_supported = vec![Algorithm::ES256];
+
+        if self.par {
+            metadata.extra.pushed_authorization_request_endpoint = Some(self.par_endpoint());
+            metadata.extra.require_pushed_authorization_requests = true;
+        }
+
+        metadata
+    }
+
+    /// Credential issuer identifier URL.
+    pub fn credential_issuer(&self) -> UriBuf {
+        match &self.public_url {
+            Some(url) => url.clone(),
+            None => UriBuf::new(format!("http://127.0.0.1:{}", self.port).into_bytes()).unwrap(),
+        }
+    }
+
+    /// Credential Endpoint URL.
+    pub fn credential_endpoint(&self) -> UriBuf {
+        UriBuf::new(format!("{}/credential", self.credential_issuer()).into_bytes()).unwrap()
+    }
+
+    /// Deferred Credential Endpoint URL.
+    fn deferred_credential_endpoint(&self) -> Option<UriBuf> {
+        Some(
+            UriBuf::new(format!("{}/deferred_credential", self.credential_issuer()).into_bytes())
+                .unwrap(),
+        )
+    }
+
+    /// Nonce Endpoint URL.
+    fn nonce_endpoint(&self) -> Option<UriBuf> {
+        Some(UriBuf::new(format!("{}/nonce", self.credential_issuer()).into_bytes()).unwrap())
+    }
+
+    /// Notification Endpoint URL.
+    fn notification_endpoint(&self) -> Option<UriBuf> {
+        Some(
+            UriBuf::new(format!("{}/notification", self.credential_issuer()).into_bytes()).unwrap(),
+        )
+    }
+
+    /// Supported credential configurations.
+    ///
+    /// To be put in the issuer metadata.
+    fn credential_configurations_supported(&self) -> IndexMap<String, CredentialConfiguration> {
+        self.credential_configurations
+            .iter()
+            .map(|(id, config)| (id.clone(), config.metadata()))
+            .collect()
+    }
+
+    /// Credential issuer metadata.
+    pub fn credential_issuer_metadata(&self) -> CredentialIssuerMetadata {
+        CredentialIssuerMetadata {
+            credential_issuer: self.credential_issuer(),
+            credential_endpoint: self.credential_endpoint(),
+            deferred_credential_endpoint: self.deferred_credential_endpoint(),
+            nonce_endpoint: self.nonce_endpoint(),
+            notification_endpoint: self.notification_endpoint(),
+            credential_request_encryption: None,
+            credential_response_encryption: None,
+            batch_credential_issuance: None,
+            // The issuer is also the Authorization Server; list it explicitly so
+            // the wallet can select it (OID4VCI §12.2.3).
+            authorization_servers: vec![self.credential_issuer()],
+            display: vec![CredentialIssuerDisplay::new("Test Credential Issuer")],
+            credential_configurations_supported: self.credential_configurations_supported(),
+        }
+    }
+
+    /// Credential authorization details.
+    pub fn authorization_details(&self) -> Vec<CredentialAuthorizationDetailsResponse> {
+        self.credential_configurations
+            .iter()
+            .map(|(id, c)| CredentialAuthorizationDetailsResponse {
+                credential_configuration_id: id.clone(),
+                claims: vec![],
+                credential_identifiers: c.credentials.keys().cloned().collect(),
+                params: Default::default(),
+            })
+            .collect()
+    }
+
+    /// Gets the credential with the given identifier.
+    pub fn get_credential(
+        &self,
+        id: &str,
+    ) -> Option<(&CredentialConfigurationConfig, &serde_json::Value)> {
+        for (_, config) in &self.credential_configurations {
+            if let Some(value) = config.credentials.get(id) {
+                return Some((config, value));
+            }
+        }
+
+        None
+    }
+}
+
+#[derive(Deserialize)]
+pub struct CredentialConfigurationConfig {
+    /// Scope.
+    pub scope: Option<ScopeBuf>,
+
+    /// Display info.
+    #[serde(default)]
+    pub display: Vec<CredentialDisplay>,
+
+    /// Credentials.
+    pub credentials: HashMap<String, serde_json::Value>,
+
+    /// Credential format.
+    #[serde(flatten)]
+    pub format: StandardCredentialFormatMetadata,
+}
+
+impl CredentialConfigurationConfig {
+    fn metadata(&self) -> CredentialConfiguration {
+        // Advertise `jwt` key proofs and `jwk` binding, as required by the HAIP
+        // profile so the wallet knows it must send a (key-attested) JWT proof.
+        let mut proof_types_supported = IndexMap::new();
+        proof_types_supported.insert(
+            "jwt".to_owned(),
+            serde_json::from_value::<KeyProofTypesSupported>(json!({
+                "proof_signing_alg_values_supported": ["ES256"]
+            }))
+            .unwrap(),
+        );
+
+        CredentialConfiguration {
+            scope: self.scope.clone(),
+            credential_signing_alg_values_supported: vec![json!("ES256")],
+            cryptographic_binding_methods_supported: vec![CryptographicBindingMethod::Jwk],
+            proof_types_supported,
+            claims: vec![],
+            format: self.format.clone(),
+            display: self.display.clone(),
+        }
+    }
+
+    pub async fn sign(
+        &self,
+        issuer: &str,
+        key: &JWK,
+        client_id: Option<&ClientId>,
+        credential: &serde_json::Value,
+        key_binding: Option<&JWK>,
+    ) -> serde_json::Value {
+        match &self.format {
+            StandardCredentialFormatMetadata::DcSdJwt(format) => {
+                sign_dc_sd_jwt(issuer, key, client_id, credential, key_binding, format).await
+            }
+            _ => todo!(),
+        }
+    }
+}
+
+async fn sign_dc_sd_jwt(
+    issuer: &str,
+    key: &JWK,
+    client_id: Option<&ClientId>,
+    credential: &serde_json::Value,
+    key_binding: Option<&JWK>,
+    format: &DcSdJwtFormatMetadata,
+) -> serde_json::Value {
+    let mut claims = credential.clone();
+    let obj = claims
+        .as_object_mut()
+        .expect("credential claims must be a JSON object");
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    obj.insert("iss".to_owned(), json!(issuer));
+    obj.insert("vct".to_owned(), json!(format.vct));
+    obj.insert("iat".to_owned(), json!(now));
+    // HAIP §6.1: limit the credential's validity.
+    obj.insert("exp".to_owned(), json!(now + 3600));
+
+    if let Some(client_id) = client_id {
+        obj.insert("sub".to_owned(), json!(client_id.as_str()));
+    }
+
+    // SD-JWT VC holder binding (RFC 7800 `cnf`): bind the credential to the key
+    // the wallet proved possession of, as a public JWK.
+    if let Some(key_binding) = key_binding {
+        obj.insert("cnf".to_owned(), json!({ "jwk": key_binding.to_public() }));
+    }
+
+    // Build the issuer-signed JWT with the SD-JWT VC media type (`typ`) and the
+    // issuer's certificate chain in the `x5c` JOSE header, so the wallet can
+    // validate the signature against the credential trust anchor (HAIP §6.1.1,
+    // SD-JWT VC §3.2.1).
+    let mut header = json!({ "alg": "ES256", "typ": "dc+sd-jwt" });
+    if let Some(x5c) = &key.x509_certificate_chain {
+        header["x5c"] = json!(x5c);
+    }
+
+    let b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    let signing_input = format!(
+        "{}.{}",
+        b64.encode(serde_json::to_vec(&header).unwrap()),
+        b64.encode(serde_json::to_vec(&claims).unwrap()),
+    );
+    let signature = key.sign_bytes(signing_input.as_bytes()).await.unwrap();
+    let jws = format!("{signing_input}.{}", b64.encode(signature));
+
+    // SD-JWT with no concealed claims: `<issuer-signed JWT>~`.
+    serde_json::Value::String(format!("{jws}~"))
+}

--- a/examples/issuer-conformance/crypto/generate.sh
+++ b/examples/issuer-conformance/crypto/generate.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+cd $(dirname "$0")
+
+# Cryptographic material for the issuer conformance tests.
+#
+# Here the conformance suite plays the *wallet* and our code is the *issuer*
+# under test, so we generate:
+#   - ca:              the trust anchor for issued Credentials and Status Lists.
+#   - issuer:          the issuer's Credential signing key + X.509 cert (x5c
+#                      chains to the CA).
+#   - attester:        the Client Attester key the suite-wallet uses to sign the
+#                      Client Attestation (its `issuer`/anchor are configured in
+#                      the suite).
+#   - key-attestation: the key the suite-wallet uses to sign Key Attestations.
+#   - wallet:          the holder/client key (its `did:jwk` is the `client_id`).
+#   - wallet2:         a second holder/client identity, for tests that exercise
+#                      two distinct clients (e.g. happy-flow-multiple-clients).
+
+# Detect step CLI command name (Homebrew uses `step`, other installs use `$STEP`).
+if command -v step &> /dev/null; then
+  STEP=step
+elif command -v step-cli &> /dev/null; then
+  STEP=step-cli
+else
+  echo "Error: neither 'step' nor 'step-cli' found. Install from https://smallstep.com/docs/step-cli/installation/" >&2
+  exit 1
+fi
+
+# Re-create sub-directories.
+rm -rf ca attester issuer key-attestation wallet wallet2
+mkdir -p ca attester issuer key-attestation wallet wallet2
+
+# Create root CA (Credential / Status List Trust Anchor).
+$STEP certificate create "Test CA" ca/cert.pem ca/key.pem --profile root-ca --subtle --insecure --no-password -f
+
+# Create Client Attester JWK.
+$STEP crypto jwk create attester/jwk.pub.json attester/jwk.json --insecure --no-password -f
+
+# Compute Client Attester DID.
+attester_did="did:jwk:$(cat attester/jwk.pub.json | jq -Sc 'del(.kid)' | tr -d '\n' | $STEP base64 -u -r)"
+
+# Save Client Attester DID.
+printf $attester_did > attester/did
+
+# Convert Client Attester JWK to PEM.
+$STEP crypto key format attester/jwk.json -f --pem --out attester/key.pem --insecure --no-password
+
+# Create Client Attester X.509 Certificate.
+$STEP certificate create "Wallet" attester/cert.pem --key attester/key.pem --ca ca/cert.pem --ca-key ca/key.pem --profile leaf -f
+
+# Add the X.509 Certificate to the Client Attester JWK.
+jq --arg id "${attester_did}#0" --arg cert "$(cat attester/cert.pem | $STEP base64 -r)" '.kid = $id | .x5c = [$cert]' attester/jwk.json | sponge attester/jwk.json
+jq --arg id "${attester_did}#0" --arg cert "$(cat attester/cert.pem | $STEP base64 -r)" '.kid = $id | .x5c = [$cert]' attester/jwk.pub.json | sponge attester/jwk.pub.json
+
+# Create Key Attestation JWK.
+$STEP crypto jwk create key-attestation/jwk.pub.json key-attestation/jwk.json --insecure --no-password -f
+
+# Convert Key Attestation JWK to PEM.
+$STEP crypto key format key-attestation/jwk.json -f --pem --out key-attestation/key.pem --insecure --no-password
+
+# Create Key Attestation X.509 Certificate.
+$STEP certificate create "Key Attestation" key-attestation/cert.pem --key key-attestation/key.pem --ca ca/cert.pem --ca-key ca/key.pem --profile leaf -f
+
+# Add the X.509 Certificate to the Key Attestation JWK.
+jq --arg cert "$(cat key-attestation/cert.pem | $STEP base64 -r)" '.x5c = [$cert]' key-attestation/jwk.json | sponge key-attestation/jwk.json
+jq --arg cert "$(cat key-attestation/cert.pem | $STEP base64 -r)" '.x5c = [$cert]' key-attestation/jwk.pub.json | sponge key-attestation/jwk.pub.json
+
+# Create Issuer JWK.
+$STEP crypto jwk create issuer/jwk.pub.json issuer/jwk.json --insecure --no-password -f
+
+# Convert Issuer JWK to PEM.
+$STEP crypto key format issuer/jwk.json --pem --out issuer/key.pem --insecure --no-password --f
+
+# Create Issuer X.509 Certificate.
+$STEP certificate create "Issuer" issuer/cert.pem --key issuer/key.pem --ca ca/cert.pem --ca-key ca/key.pem --profile leaf -f
+
+# Add the X.509 Certificate to the Issuer JWK.
+jq --arg cert "$(cat issuer/cert.pem | $STEP base64 -r)" '.x5c = [$cert]' issuer/jwk.json | sponge issuer/jwk.json
+jq --arg cert "$(cat issuer/cert.pem | $STEP base64 -r)" '.x5c = [$cert]' issuer/jwk.pub.json | sponge issuer/jwk.pub.json
+
+# Generate Wallet (holder / client) JWK.
+$STEP crypto jwk create wallet/jwk.pub.json wallet/jwk.json --insecure --no-password -f
+
+# Compute Wallet DID.
+wallet_did="did:jwk:$(cat wallet/jwk.pub.json | jq -Sc 'del(.kid)' | tr -d '\n' | $STEP base64 -u -r)"
+
+# Set Wallet Key ID.
+jq --arg id "${wallet_did}#0" '.kid = $id' wallet/jwk.json | sponge wallet/jwk.json
+jq --arg id "${wallet_did}#0" '.kid = $id' wallet/jwk.pub.json | sponge wallet/jwk.pub.json
+
+# Print Wallet DID.
+printf $wallet_did > wallet/did
+
+# Generate second Wallet (holder / client) JWK, for multiple-clients tests.
+$STEP crypto jwk create wallet2/jwk.pub.json wallet2/jwk.json --insecure --no-password -f
+
+# Compute second Wallet DID.
+wallet2_did="did:jwk:$(cat wallet2/jwk.pub.json | jq -Sc 'del(.kid)' | tr -d '\n' | $STEP base64 -u -r)"
+
+# Set second Wallet Key ID.
+jq --arg id "${wallet2_did}#0" '.kid = $id' wallet2/jwk.json | sponge wallet2/jwk.json
+jq --arg id "${wallet2_did}#0" '.kid = $id' wallet2/jwk.pub.json | sponge wallet2/jwk.pub.json
+
+# Print second Wallet DID.
+printf $wallet2_did > wallet2/did

--- a/examples/issuer-conformance/error.rs
+++ b/examples/issuer-conformance/error.rs
@@ -1,0 +1,36 @@
+use axum::{
+    body::Body,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("unknown credential offer")]
+    UnknownCredentialOffer,
+
+    #[error("expired")]
+    Expired,
+
+    #[error("unauthorized")]
+    Unauthorized,
+
+    #[error("missing redirect URL")]
+    MissingRedirectUrl,
+
+    #[error("unknown request URL")]
+    UnknownRequestUrl,
+
+    #[error("invalid request")]
+    InvalidRequest,
+}
+
+impl IntoResponse for Error {
+    fn into_response(self) -> Response {
+        Response::builder()
+            .status(StatusCode::BAD_REQUEST)
+            .header("Content-Type", "text/html")
+            .body(Body::from(format!("<!DOCTYPE html><html><head><title>Error</title></head><body><h1>Error</h1><p>{self}</p></body></html>")))
+            .unwrap()
+    }
+}

--- a/examples/issuer-conformance/main.rs
+++ b/examples/issuer-conformance/main.rs
@@ -1,0 +1,231 @@
+//! OID4VCI 1.0 issuer conformance server.
+//!
+//! An OID4VCI Credential Issuer + OAuth2 Authorization Server (with PAR) driven
+//! by the OpenID Foundation conformance suite acting as the wallet. Covers the
+//! `oid4vci-1_0-issuer-*` and `fapi2-security-profile-final-*` test plans.
+//!
+//! The suite (running in the cloud) must reach this server, so expose it with a
+//! tunnel (e.g. ngrok) and pass the public URL via `--public-url`; that URL is
+//! used as the Credential Issuer identifier and in all advertised endpoints.
+//!
+//! See `examples/issuer-conformance/README.md` for the full setup.
+
+use std::{path::PathBuf, process::ExitCode, sync::Arc};
+
+use ::oid4vci::server::Oid4vciRouter;
+use axum::routing::{get, post};
+use clap::Parser;
+use iref::UriBuf;
+use open_auth2::{reqwest, server::OAuth2Router};
+use ssi::JWK;
+use tokio::{
+    fs,
+    io::{AsyncBufReadExt, BufReader},
+};
+
+mod config;
+mod error;
+mod oauth2;
+mod oid4vci;
+
+use config::Config;
+use error::Error;
+use oauth2::OAuth2State;
+
+use crate::oid4vci::Oid4vciState;
+
+/// OID4VCI issuer conformance server.
+#[derive(Parser)]
+struct Params {
+    /// Public URL where the suite can reach this issuer (e.g. the ngrok URL).
+    ///
+    /// Used as the Credential Issuer identifier and to build every advertised
+    /// endpoint. Must match `vci.credential_issuer_url` in `test.json`.
+    #[arg(short = 'P', long)]
+    public_url: UriBuf,
+
+    /// Listening port.
+    #[arg(short, long, default_value = "3000")]
+    port: u32,
+
+    /// Path to the issuer's Credential signing JWK.
+    ///
+    /// Must carry an `x5c` chain to the Credential Trust Anchor configured in
+    /// the suite (the generated `crypto/issuer/jwk.json` already does).
+    #[arg(
+        short = 'k',
+        long,
+        default_value = "examples/issuer-conformance/crypto/issuer/jwk.json"
+    )]
+    issuer_jwk: PathBuf,
+
+    /// Path to the trusted Client Attester's public JWK.
+    ///
+    /// Used to verify the signature on the Client Attestation JWT presented for
+    /// Attestation-Based Client Authentication (the generated
+    /// `crypto/attester/jwk.pub.json`, whose private half the suite signs with).
+    #[arg(
+        short = 'a',
+        long,
+        default_value = "examples/issuer-conformance/crypto/attester/jwk.pub.json"
+    )]
+    attester_jwk: PathBuf,
+
+    /// Registered client redirect URI(s).
+    ///
+    /// The redirect URIs the client (the suite-wallet) is registered with — i.e.
+    /// the suite's callback, e.g.
+    /// `https://www.certification.openid.net/test/a/<alias>/callback`. When set,
+    /// the PAR endpoint rejects an authorization request whose `redirect_uri` is
+    /// not one of these (FAPI2 §5.3.1.1 / RFC 6749 §3.1.2.3) instead of
+    /// redirecting to it. May be repeated. When omitted, any `redirect_uri` is
+    /// accepted.
+    #[arg(short = 'r', long = "redirect-uri")]
+    redirect_uris: Vec<UriBuf>,
+
+    /// Require an interactive approve/deny consent step at the Authorization
+    /// Endpoint instead of auto-approving.
+    ///
+    /// Enable this to run the FAPI2 tests that need the user to deny consent
+    /// (`user-rejects-authentication`) or to reuse a `request_uri` before
+    /// authentication completes. Leave it off (the default) for the headless,
+    /// auto-approving flow every other test expects.
+    #[arg(long)]
+    manual_consent: bool,
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    env_logger::init();
+    let params = Params::parse();
+
+    match run(params).await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            log::error!("{e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run(params: Params) -> Result<(), anyhow::Error> {
+    let jwk: JWK = fs::read_to_string(&params.issuer_jwk).await?.parse()?;
+    let attester_jwk: JWK = fs::read_to_string(&params.attester_jwk).await?.parse()?;
+
+    let mut config = Config::new(params.public_url.clone(), params.port, params.redirect_uris);
+    config.manual_consent = params.manual_consent;
+
+    let addr = format!("0.0.0.0:{}", config.port);
+
+    // Values needed to build issuer-initiated Credential Offers.
+    let issuer_url = params.public_url.clone();
+    let credential_configuration_ids: Vec<String> =
+        config.credential_configurations.keys().cloned().collect();
+
+    let server = Arc::new(Server {
+        config,
+        jwk,
+        attester_jwk,
+        oid4vci: Oid4vciState::default(),
+        oauth2: OAuth2State::default(),
+    });
+
+    // Setup routes.
+    //
+    // The PAR endpoint is wired with a custom handler (rather than open_auth2's
+    // `oauth2_par_route`) so it can read the `OAuth-Client-Attestation`(-PoP)
+    // HTTP headers and authenticate the client (ATCA draft-07 §6) before
+    // processing the pushed request.
+    let router = axum::Router::new()
+        .route("/health", get(health))
+        .oauth2_routes()
+        .route("/par", post(oauth2::par))
+        .route("/authorize/decision", get(oauth2::authorize_decision))
+        .oid4vci_routes()
+        .route("/offer/new", get(oid4vci::new_credential_offer))
+        .route(
+            "/offer/{credential_offer_token}",
+            get(oid4vci::credential_offer),
+        )
+        .with_state(server);
+
+    // Start the server. It supports every flow out of the box: wallet-initiated
+    // and Pre-Authorized Code flows are driven entirely through the HTTP
+    // endpoints, while issuer-initiated flows are driven through the interactive
+    // prompt below — all without restarting the process.
+    println!("Listening on {addr} (public URL: {})...", params.public_url);
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+
+    let server_task = tokio::spawn(async move { axum::serve(listener, router).await });
+
+    drive_issuer_initiated_offers(&issuer_url, &credential_configuration_ids).await?;
+
+    server_task.await?.map_err(Into::into)
+}
+
+/// Prompts for wallet `credential_offer_endpoint`s on stdin and delivers a
+/// Credential Offer (by value) to each, as needed by the issuer-initiated flow
+/// (OID4VCI §4.1). Always available while the server runs; other flows simply
+/// ignore it. When stdin is closed (non-interactive), it returns immediately and
+/// the server keeps serving.
+async fn drive_issuer_initiated_offers(
+    issuer_url: &UriBuf,
+    credential_configuration_ids: &[String],
+) -> Result<(), anyhow::Error> {
+    let http_client = reqwest::Client::new();
+    let mut lines = BufReader::new(tokio::io::stdin()).lines();
+
+    eprintln!();
+    eprintln!("Ready. For the issuer-initiated flow, paste the wallet's");
+    eprintln!("`credential_offer_endpoint` (exported by the conformance test) to");
+    eprintln!("deliver a Credential Offer. Other flows need nothing here. Ctrl+C to quit.");
+    eprintln!();
+    eprint!("credential_offer_endpoint> ");
+
+    while let Some(line) = lines.next_line().await? {
+        let endpoint = line.trim();
+        if !endpoint.is_empty() {
+            let offer = serde_json::json!({
+                "credential_issuer": issuer_url.as_str(),
+                "credential_configuration_ids": credential_configuration_ids,
+                "grants": { "authorization_code": {} }
+            });
+
+            // Deliver the offer by value: `{endpoint}?credential_offer=<JSON>`.
+            let query = serde_urlencoded::to_string([(
+                "credential_offer",
+                serde_json::to_string(&offer)?,
+            )])?;
+            let url = format!("{endpoint}?{query}");
+
+            match http_client.get(&url).send().await {
+                Ok(response) => {
+                    eprintln!(
+                        "Delivered Credential Offer to {endpoint} (HTTP {}).",
+                        response.status()
+                    )
+                }
+                Err(e) => eprintln!("Failed to deliver Credential Offer: {e}"),
+            }
+        }
+        eprint!("credential_offer_endpoint> ");
+    }
+
+    Ok(())
+}
+
+struct Server {
+    config: Config,
+
+    jwk: JWK,
+
+    /// Trusted Client Attester public key, used to verify Client Attestation
+    /// JWTs (Attestation-Based Client Authentication).
+    attester_jwk: JWK,
+
+    oid4vci: Oid4vciState,
+
+    oauth2: OAuth2State,
+}
+
+async fn health() {}

--- a/examples/issuer-conformance/oauth2.rs
+++ b/examples/issuer-conformance/oauth2.rs
@@ -232,6 +232,14 @@ struct PkceParams {
     code_challenge_method: Option<String>,
 }
 
+/// `response_type` parameter, read on its own because `serde_urlencoded` does
+/// not enforce the internally-tagged `response_type=code` discriminator on
+/// [`AuthorizationCodeAuthorizationRequest`].
+#[derive(Deserialize, Default)]
+struct ResponseTypeParam {
+    response_type: Option<String>,
+}
+
 /// Pushed Authorization Request endpoint.
 ///
 /// Wraps the OAuth2 PAR handling with the request-level checks the AS must
@@ -259,6 +267,17 @@ pub async fn par(State(server): State<Arc<Server>>, headers: HeaderMap, body: St
         .is_some()
     {
         log::warn!("PAR: request must not contain a `request_uri` parameter");
+        return OAuth2ServerError::InvalidRequest.into_response();
+    }
+
+    // FAPI2 §5.3.2.2: only `response_type=code` is permitted. Anything else
+    // (e.g. `code id_token`, which would return an `id_token` through the
+    // browser) MUST be rejected (RFC 6749 §4.1.2.1 `unsupported_response_type`).
+    let response_type = serde_urlencoded::from_str::<ResponseTypeParam>(&body)
+        .ok()
+        .and_then(|p| p.response_type);
+    if response_type.as_deref() != Some("code") {
+        log::warn!("PAR: unsupported response_type {response_type:?}");
         return OAuth2ServerError::InvalidRequest.into_response();
     }
 

--- a/examples/issuer-conformance/oauth2.rs
+++ b/examples/issuer-conformance/oauth2.rs
@@ -520,6 +520,16 @@ impl OAuth2Server for Server {
                     }
                 };
 
+                // FAPI2 §5.3.2.2: access tokens MUST be sender-constrained. This
+                // issuer uses DPoP (RFC 9449) as its holder-of-key mechanism, so
+                // an authorization_code token request MUST present a DPoP proof —
+                // without one the AS cannot bind the token and rejects the request
+                // rather than issue a bearer token.
+                if proof_jkt.is_none() {
+                    log::warn!("token: missing DPoP proof; FAPI2 requires a holder-of-key (DPoP) proof");
+                    return Err(OAuth2ServerError::InvalidRequest);
+                }
+
                 // RFC 9449 §10.1: if the request was pre-bound at PAR via
                 // `dpop_jkt`, the token proof's key MUST match it.
                 if let Some(par_jkt) = &m.dpop_jkt {

--- a/examples/issuer-conformance/oauth2.rs
+++ b/examples/issuer-conformance/oauth2.rs
@@ -1,0 +1,745 @@
+use core::fmt;
+use std::{borrow::Cow, sync::Arc, time::Duration};
+
+use axum::{
+    body::Body,
+    extract::{Query, State},
+    http::{HeaderMap, StatusCode},
+    response::{Html, IntoResponse, Response},
+};
+use base64::Engine as _;
+use dashmap::DashMap;
+use iref::UriBuf;
+use oid4vci::{
+    authorization::{
+        oauth2::{
+            client_attestation::{
+                ClientAttestationAndPopRef, OAUTH_CLIENT_ATTESTATION, OAUTH_CLIENT_ATTESTATION_POP,
+            },
+            dpop::DPOP,
+        },
+        server::{Oid4VciAuthorizationServerParams, Oid4vciAuthorizationServerMetadata},
+    },
+    client::Oid4vciTokenParams,
+};
+use open_auth2::{
+    endpoints::{
+        pushed_authorization::{PushedAuthorizationRequest, PushedAuthorizationResponse},
+        token::TokenResponse,
+    },
+    grant::{
+        authorization_code::AuthorizationCodeAuthorizationRequest,
+        pre_authorized_code::PreAuthorizedCodeTokenRequest,
+    },
+    server::{ErrorCode, ErrorResponse, OAuth2Server, OAuth2ServerError},
+    AccessToken, AccessTokenBuf, ClientId, ClientIdBuf, CodeBuf, Stateful,
+};
+use rand::{
+    distr::{Alphanumeric, SampleString},
+    rng,
+};
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+use sha2::{Digest, Sha256};
+use ssi::claims::jws::Jws;
+use time::UtcDateTime;
+
+use crate::{Error, Server};
+
+/// Authorization code lifetime. FAPI2 §5.3.2.1-11 requires short-lived codes;
+/// the conformance suite expects expiry within ~60s.
+const AUTHORIZATION_CODE_TTL: Duration = Duration::from_secs(60);
+
+#[derive(Default)]
+pub struct OAuth2State {
+    pre_authorized_codes: DashMap<String, PreAuthorizedCodeMetadata>,
+
+    par: DashMap<UriBuf, PushedAuthorization>,
+
+    authorization_code: DashMap<CodeBuf, AuthorizationCodeMetadata>,
+
+    access_tokens: DashMap<AccessTokenBuf, AccessTokenMetadata>,
+}
+
+impl OAuth2State {
+    pub fn new_pre_authorized_code(&self, m: PreAuthorizedCodeMetadata) -> String {
+        let code = rand::distr::Alphanumeric.sample_string(&mut rand::rng(), 30);
+        self.pre_authorized_codes.insert(code.clone(), m);
+        code
+    }
+
+    pub fn access_token_metadata(
+        &self,
+        access_token: &AccessToken,
+    ) -> Option<dashmap::mapref::one::Ref<'_, AccessTokenBuf, AccessTokenMetadata>> {
+        self.access_tokens.get(access_token)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+pub enum AuthorizationRequest {
+    Pushed(PushedAuthorizationRequest),
+    Direct(AuthorizationCodeAuthorizationRequest),
+}
+
+impl Server {
+    async fn authorize_direct(
+        &self,
+        Stateful {
+            state,
+            value: request,
+        }: Stateful<AuthorizationCodeAuthorizationRequest>,
+        dpop_jkt: Option<String>,
+        code_challenge: String,
+    ) -> Result<Redirect, Error> {
+        match request.redirect_url(None).map(ToOwned::to_owned) {
+            Some(redirect_uri) => {
+                let client_id = request.client_id.clone();
+                let code = CodeBuf::new(Alphanumeric.sample_string(&mut rng(), 30)).unwrap();
+                let full_redirect_uri = request.grant(state, code.clone(), None).unwrap();
+
+                // RFC 9207 / FAPI2 §5.3.2.2: the authorization response MUST carry
+                // the issuer identifier so the wallet can detect mix-up attacks.
+                let iss = serde_urlencoded::to_string([(
+                    "iss",
+                    self.config.credential_issuer().as_str(),
+                )])
+                .unwrap();
+                let redirect_str = full_redirect_uri.as_str();
+                let sep = if redirect_str.contains('?') { '&' } else { '?' };
+                let full_redirect_uri =
+                    UriBuf::new(format!("{redirect_str}{sep}{iss}").into_bytes()).unwrap();
+
+                let m = AuthorizationCodeMetadata {
+                    client_id,
+                    redirect_uri,
+                    // Carry the DPoP key binding established at PAR so the token
+                    // endpoint can enforce it (RFC 9449 §10.1).
+                    dpop_jkt,
+                    // Carry the PKCE challenge so the token endpoint can verify
+                    // the code_verifier (RFC 7636 §4.6).
+                    code_challenge,
+                    // Authorization codes are short-lived (FAPI2 §5.3.2.1-11).
+                    expires_at: UtcDateTime::now() + AUTHORIZATION_CODE_TTL,
+                };
+
+                self.oauth2.authorization_code.insert(code, m);
+
+                Ok(Redirect(full_redirect_uri))
+            }
+            None => Err(Error::MissingRedirectUrl),
+        }
+    }
+
+    /// Renders the interactive approve/deny consent page for `manual_consent`
+    /// mode. The links carry the decision to `/authorize/decision`, which is
+    /// where the `request_uri` is finally consumed.
+    fn consent_page(&self, request_uri: &iref::Uri) -> Html<String> {
+        let query = serde_urlencoded::to_string([("request_uri", request_uri.as_str())]).unwrap();
+        let base = self.config.credential_issuer();
+        Html(format!(
+            "<!DOCTYPE html><html><head><title>Authorize</title></head><body>\
+             <h1>Authorization Request</h1>\
+             <p>The client is requesting authorization.</p>\
+             <p><a href=\"{base}/authorize/decision?{query}&amp;decision=approve\">Approve</a></p>\
+             <p><a href=\"{base}/authorize/decision?{query}&amp;decision=deny\">Deny</a></p>\
+             </body></html>"
+        ))
+    }
+
+    /// Authenticates the client with Attestation-Based Client Authentication
+    /// (ATCA draft-07 §6): the `OAuth-Client-Attestation` and
+    /// `OAuth-Client-Attestation-PoP` HTTP headers must carry a Client
+    /// Attestation signed by our trusted attester and a PoP signed by the
+    /// attested key, both with claims matching this request.
+    ///
+    /// The advertised `token_endpoint_auth_methods_supported` is
+    /// `attest_jwt_client_auth`, so this authentication is mandatory.
+    async fn authenticate_client(
+        &self,
+        headers: &HeaderMap,
+        client_id: &ClientId,
+    ) -> Result<(), String> {
+        let header_str = |name: &_| headers.get(name).and_then(|v| v.to_str().ok());
+
+        let (Some(attestation), Some(pop)) = (
+            header_str(&OAUTH_CLIENT_ATTESTATION),
+            header_str(&OAUTH_CLIENT_ATTESTATION_POP),
+        ) else {
+            return Err("missing client attestation headers".to_owned());
+        };
+
+        let attestation = Jws::new(attestation).map_err(|_| "malformed attestation JWT")?;
+        let pop = Jws::new(pop).map_err(|_| "malformed attestation PoP JWT")?;
+
+        ClientAttestationAndPopRef {
+            client_attestation: attestation,
+            client_attestation_pop: pop,
+        }
+        // The attestation `sub` must be `client_id`, and the PoP `aud` is this
+        // Authorization Server's issuer identifier.
+        .verify(
+            &self.attester_jwk,
+            None,
+            client_id,
+            self.config.credential_issuer().as_str(),
+            None,
+        )
+        .await
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+    }
+}
+
+/// Returns the JWK SHA-256 thumbprint (RFC 7638) of the key in the `DPoP` proof
+/// header, if a DPoP proof is present. This is the `jkt` an access token issued
+/// for the request is bound to (RFC 9449).
+fn dpop_header_jkt(headers: &HeaderMap) -> Result<Option<String>, String> {
+    let Some(dpop) = headers.get(&DPOP).and_then(|v| v.to_str().ok()) else {
+        return Ok(None);
+    };
+
+    let dpop = Jws::new(dpop).map_err(|_| "malformed DPoP proof")?;
+    let decoded = dpop.decode().map_err(|_| "undecodable DPoP proof")?;
+    let jwk = decoded
+        .header()
+        .jwk
+        .as_ref()
+        .ok_or("DPoP proof is missing its `jwk` header")?;
+
+    jwk.thumbprint().map(Some).map_err(|e| e.to_string())
+}
+
+/// `dpop_jkt` PAR parameter (RFC 9449 §10.1), parsed on its own so the rest of
+/// the form deserializes independently of this DPoP extension.
+#[derive(Deserialize, Default)]
+struct DpopJktParam {
+    dpop_jkt: Option<String>,
+}
+
+/// Used to detect a `request_uri` parameter, which RFC 9126 §2.1 forbids in a
+/// PAR request.
+#[derive(Deserialize, Default)]
+struct RequestUriParam {
+    request_uri: Option<String>,
+}
+
+/// PKCE parameters (RFC 7636), required with `S256` by FAPI2 §5.2.2-18.
+#[derive(Deserialize, Default)]
+struct PkceParams {
+    code_challenge: Option<String>,
+    code_challenge_method: Option<String>,
+}
+
+/// Pushed Authorization Request endpoint.
+///
+/// Wraps the OAuth2 PAR handling with the request-level checks the AS must
+/// perform before accepting a pushed request: Attestation-Based Client
+/// Authentication (ATCA draft-07 §6) from the request headers, and the
+/// `dpop_jkt`/DPoP-proof binding cross-check (RFC 9449 §10.1). On failure the AS
+/// responds `invalid_client` / `invalid_request` (the suite accepts 400/401).
+///
+/// The raw body is parsed directly (rather than via `Form`) so the `dpop_jkt`
+/// DPoP extension parameter can be read alongside the standard request.
+pub async fn par(State(server): State<Arc<Server>>, headers: HeaderMap, body: String) -> Response {
+    let request: Stateful<AuthorizationCodeAuthorizationRequest> =
+        match serde_urlencoded::from_str(&body) {
+            Ok(request) => request,
+            Err(e) => {
+                log::warn!("PAR: malformed request: {e}");
+                return OAuth2ServerError::InvalidRequest.into_response();
+            }
+        };
+
+    // RFC 9126 §2.1: a PAR request MUST NOT contain a `request_uri` parameter.
+    if serde_urlencoded::from_str::<RequestUriParam>(&body)
+        .ok()
+        .and_then(|p| p.request_uri)
+        .is_some()
+    {
+        log::warn!("PAR: request must not contain a `request_uri` parameter");
+        return OAuth2ServerError::InvalidRequest.into_response();
+    }
+
+    // FAPI2 §5.2.2-18 / RFC 7636: PKCE with the `S256` method is mandatory.
+    let pkce = serde_urlencoded::from_str::<PkceParams>(&body).unwrap_or_default();
+    let code_challenge = match pkce.code_challenge {
+        Some(c) if pkce.code_challenge_method.as_deref() == Some("S256") => c,
+        _ => {
+            log::warn!(
+                "PAR: missing PKCE `code_challenge` or `code_challenge_method` is not `S256`"
+            );
+            return OAuth2ServerError::InvalidRequest.into_response();
+        }
+    };
+
+    // FAPI2 §5.3.1.1 / RFC 6749 §3.1.2.3: a `redirect_uri` that is not registered
+    // for the client MUST be rejected here — the AS must NOT redirect to it.
+    let registered = &server.config.registered_redirect_uris;
+    if !registered.is_empty()
+        && !matches!(&request.value.redirect_uri, Some(uri) if registered.contains(uri))
+    {
+        log::warn!(
+            "PAR: unregistered redirect_uri {:?}",
+            request.value.redirect_uri
+        );
+        return OAuth2ServerError::InvalidRequest.into_response();
+    }
+
+    if let Err(e) = server
+        .authenticate_client(&headers, &request.value.client_id)
+        .await
+    {
+        log::warn!("PAR: client authentication failed: {e}");
+        return OAuth2ServerError::InvalidClient.into_response();
+    }
+
+    // Determine the DPoP key the request binds to (RFC 9449 §10.1): the `DPoP`
+    // proof presented at PAR and/or the `dpop_jkt` parameter. If both are given
+    // they MUST agree. The resulting thumbprint is carried forward so the token
+    // endpoint can enforce that the same key is used.
+    let proof_jkt = match dpop_header_jkt(&headers) {
+        Ok(jkt) => jkt,
+        Err(e) => {
+            log::warn!("PAR: invalid DPoP proof: {e}");
+            return OAuth2ServerError::InvalidRequest.into_response();
+        }
+    };
+    let param_jkt = serde_urlencoded::from_str::<DpopJktParam>(&body)
+        .ok()
+        .and_then(|p| p.dpop_jkt);
+
+    if let (Some(param), Some(proof)) = (&param_jkt, &proof_jkt) {
+        if param != proof {
+            log::warn!("PAR: dpop_jkt `{param}` does not match DPoP proof key `{proof}`");
+            return OAuth2ServerError::InvalidRequest.into_response();
+        }
+    }
+
+    let dpop_jkt = param_jkt.or(proof_jkt);
+
+    server
+        .push_authorization_request(request, dpop_jkt, code_challenge)
+        .into_response()
+}
+
+impl OAuth2Server for Server {
+    type Metadata = Oid4VciAuthorizationServerParams;
+    type AuthorizationRequest = AuthorizationRequest;
+    type TokenRequest = TokenRequest;
+    type TokenResponse = TokenResponse<TokenType, Oid4vciTokenParams>;
+
+    async fn metadata(
+        &self,
+    ) -> Result<Cow<'_, Oid4vciAuthorizationServerMetadata>, OAuth2ServerError> {
+        Ok(match &self.config.authorization_server_metadata {
+            Some(metadata) => Cow::Borrowed(metadata),
+            None => Cow::Owned(self.config.default_authorization_server_metadata()),
+        })
+    }
+
+    async fn authorize(
+        &self,
+        Stateful {
+            state,
+            value: request,
+        }: Stateful<AuthorizationRequest>,
+    ) -> impl IntoResponse {
+        match request {
+            AuthorizationRequest::Direct(request) => {
+                // FAPI2 / RFC 9126: this AS requires pushed authorization
+                // requests, so a direct authorization request (no `request_uri`)
+                // is an `invalid_request`. Report the error by redirecting to a
+                // registered redirect_uri (RFC 6749 §4.1.2.1); if none is valid,
+                // surface it as an error page instead of redirecting.
+                let registered = &self.config.registered_redirect_uris;
+                let redirect_ok = matches!(
+                    &request.redirect_uri,
+                    Some(uri) if registered.is_empty() || registered.contains(uri)
+                );
+
+                if redirect_ok {
+                    let error = ErrorResponse::new(ErrorCode::InvalidRequest, None, None);
+                    match request.deny(state, error, None) {
+                        Some(uri) => Redirect(uri).into_response(),
+                        None => Error::InvalidRequest.into_response(),
+                    }
+                } else {
+                    Error::InvalidRequest.into_response()
+                }
+            }
+            AuthorizationRequest::Pushed(request) => {
+                // Validate the pushed request. In manual-consent mode we only
+                // *peek* (the `request_uri` must stay reusable until the user
+                // decides); otherwise we consume it and approve immediately.
+                if self.config.manual_consent {
+                    match self.oauth2.par.get(&request.request_uri) {
+                        Some(pa) => {
+                            if pa.expires_at < UtcDateTime::now() {
+                                return Error::Expired.into_response();
+                            }
+                            if *pa.request.client_id != request.client_id {
+                                return Error::Unauthorized.into_response();
+                            }
+                            self.consent_page(&request.request_uri).into_response()
+                        }
+                        None => Error::UnknownRequestUrl.into_response(),
+                    }
+                } else {
+                    match self.oauth2.par.remove(&request.request_uri) {
+                        Some((_, pa)) => {
+                            if pa.expires_at < UtcDateTime::now() {
+                                return Error::Expired.into_response();
+                            }
+                            if *pa.request.client_id != request.client_id {
+                                return Error::Unauthorized.into_response();
+                            }
+                            self.authorize_direct(pa.request, pa.dpop_jkt, pa.code_challenge)
+                                .await
+                                .into_response()
+                        }
+                        None => Error::UnknownRequestUrl.into_response(),
+                    }
+                }
+            }
+        }
+    }
+
+    async fn token(
+        &self,
+        headers: HeaderMap,
+        token_request: Self::TokenRequest,
+    ) -> Result<Self::TokenResponse, OAuth2ServerError> {
+        log::debug!("token request: {token_request:#?}");
+
+        let m = match token_request {
+            TokenRequest::PreAuthorizedCode(request) => {
+                let m = self
+                    .oauth2
+                    .pre_authorized_codes
+                    .get(&request.pre_authorized_code)
+                    .ok_or(OAuth2ServerError::UnauthorizedClient)?;
+
+                if let Some(expected_tx_code) = &m.tx_code {
+                    let tx_code = request
+                        .tx_code
+                        .ok_or(OAuth2ServerError::UnauthorizedClient)?;
+
+                    if tx_code != *expected_tx_code {
+                        return Err(OAuth2ServerError::UnauthorizedClient);
+                    }
+                }
+
+                AccessTokenMetadata {
+                    client_id: request.client_id,
+                    // The pre-authorized code flow here is not DPoP-bound.
+                    jkt: None,
+                }
+            }
+            TokenRequest::AuthorizationCode(request) => {
+                // Consume the authorization code: it is single-use (RFC 6749
+                // §4.1.2). An unknown or already-used code is `invalid_grant`
+                // (RFC 6749 §5.2).
+                let (_, m) = self
+                    .oauth2
+                    .authorization_code
+                    .remove(&request.code)
+                    .ok_or(OAuth2ServerError::InvalidGrant)?;
+
+                // FAPI2 §5.3.2.1-11: reject an expired authorization code.
+                if m.expires_at < UtcDateTime::now() {
+                    log::warn!("token: authorization code expired");
+                    return Err(OAuth2ServerError::InvalidGrant);
+                }
+
+                // RFC 6749 §5.2: an authorization code presented with a
+                // mismatched `client_id` or `redirect_uri` (i.e. that was issued
+                // to another client / for another redirect URI) is `invalid_grant`.
+                if !m.check_request(&request) {
+                    log::warn!(
+                        "token: authorization code does not match the request's client_id/redirect_uri"
+                    );
+                    return Err(OAuth2ServerError::InvalidGrant);
+                }
+
+                // RFC 7636 §4.6: verify the PKCE `code_verifier` against the
+                // `S256` challenge captured at PAR. A missing or non-matching
+                // verifier is `invalid_grant`.
+                let pkce_ok = request.code_verifier.as_deref().is_some_and(|verifier| {
+                    let computed = base64::engine::general_purpose::URL_SAFE_NO_PAD
+                        .encode(Sha256::digest(verifier.as_bytes()));
+                    computed == m.code_challenge
+                });
+                if !pkce_ok {
+                    log::warn!("token: missing or invalid PKCE code_verifier");
+                    return Err(OAuth2ServerError::InvalidGrant);
+                }
+
+                // The authorization code is bound to the client that obtained it.
+                // When the request authenticates with a Client Attestation, it
+                // MUST be for that same client (its `sub` must equal the code's
+                // client). Using another client's credentials is `invalid_grant`
+                // (RFC 6749 §4.1.3 / §5.2).
+                if headers.contains_key(&OAUTH_CLIENT_ATTESTATION) {
+                    if let Err(e) = self.authenticate_client(&headers, &m.client_id).await {
+                        log::warn!(
+                            "token: client attestation not bound to the authorization code: {e}"
+                        );
+                        return Err(OAuth2ServerError::InvalidGrant);
+                    }
+                }
+
+                // RFC 9449 §5: the access token is DPoP-bound to the key of the
+                // DPoP proof presented at the token endpoint. The thumbprint of
+                // that key becomes the token's `jkt`.
+                let proof_jkt = match dpop_header_jkt(&headers) {
+                    Ok(jkt) => jkt,
+                    Err(e) => {
+                        log::warn!("token: invalid DPoP proof: {e}");
+                        return Err(OAuth2ServerError::InvalidRequest);
+                    }
+                };
+
+                // RFC 9449 §10.1: if the request was pre-bound at PAR via
+                // `dpop_jkt`, the token proof's key MUST match it.
+                if let Some(par_jkt) = &m.dpop_jkt {
+                    if proof_jkt.as_ref() != Some(par_jkt) {
+                        log::warn!(
+                            "token: DPoP proof key does not match the key bound at PAR `{par_jkt}`"
+                        );
+                        return Err(OAuth2ServerError::InvalidGrant);
+                    }
+                }
+
+                // Bind the access token to the client that performed the
+                // authorization (carried by the authorization code), not the
+                // token request body — under Attestation-Based Client
+                // Authentication the body omits `client_id`. Carry the DPoP key
+                // binding (RFC 9449) so the resource server can enforce it.
+                AccessTokenMetadata {
+                    client_id: Some(m.client_id),
+                    jkt: proof_jkt.or(m.dpop_jkt),
+                }
+            }
+        };
+
+        // A DPoP-bound token (RFC 9449) is advertised with the `DPoP` token type.
+        let token_type = if m.jkt.is_some() {
+            TokenType::Dpop
+        } else {
+            TokenType::Bearer
+        };
+
+        let access_token = AccessTokenBuf::new(Alphanumeric.sample_string(&mut rng(), 30)).unwrap();
+        self.oauth2.access_tokens.insert(access_token.to_owned(), m);
+
+        let mut response = TokenResponse::new(
+            access_token,
+            token_type,
+            Oid4vciTokenParams {
+                authorization_details: self.config.authorization_details().into(),
+            },
+        );
+        // RFC 6749 §5.1 recommends advertising the access token lifetime.
+        response.expires_in = Some(3600);
+
+        Ok(response)
+    }
+}
+
+impl Server {
+    /// Stores a pushed authorization request and returns its `request_uri`
+    /// (RFC 9126). `dpop_jkt` is the DPoP key thumbprint the request is bound to,
+    /// if any, carried through to the issued authorization code (RFC 9449 §10.1).
+    fn push_authorization_request(
+        &self,
+        request: Stateful<AuthorizationCodeAuthorizationRequest>,
+        dpop_jkt: Option<String>,
+        code_challenge: String,
+    ) -> PushedAuthorizationResponse {
+        log::info!("push request: {request:#?}");
+
+        let request_uri = UriBuf::new(
+            format!(
+                "urn:ietf:params:oauth:request_uri:{}",
+                Alphanumeric.sample_string(&mut rng(), 30)
+            )
+            .into_bytes(),
+        )
+        .unwrap();
+        // Short-lived request URI (RFC 9126 §2.2 recommends a short lifetime).
+        // Kept small so the `request_uri` expiry conformance test does not have
+        // to sleep for long.
+        let expires_in = 90;
+        let expires_at = UtcDateTime::now() + Duration::from_secs(expires_in);
+
+        self.oauth2.par.insert(
+            request_uri.clone(),
+            PushedAuthorization {
+                request,
+                expires_at,
+                dpop_jkt,
+                code_challenge,
+            },
+        );
+
+        PushedAuthorizationResponse {
+            request_uri,
+            expires_in,
+        }
+    }
+}
+
+pub struct PreAuthorizedCodeMetadata {
+    pub tx_code: Option<String>,
+}
+
+pub struct AuthorizationCodeMetadata {
+    client_id: ClientIdBuf,
+    redirect_uri: UriBuf,
+    dpop_jkt: Option<String>,
+    code_challenge: String,
+    expires_at: UtcDateTime,
+}
+
+pub struct PushedAuthorization {
+    request: Stateful<AuthorizationCodeAuthorizationRequest>,
+    expires_at: UtcDateTime,
+    dpop_jkt: Option<String>,
+    code_challenge: String,
+}
+
+impl AuthorizationCodeMetadata {
+    fn check_request(&self, request: &AuthorizationCodeTokenRequest) -> bool {
+        // `client_id` in the token request body is only REQUIRED when the client
+        // is not otherwise authenticating (RFC 6749 §4.1.3). With Attestation-
+        // Based Client Authentication the client authenticates via the Client
+        // Attestation, so the body omits `client_id`; only enforce it if present.
+        request
+            .client_id
+            .as_ref()
+            .map_or(true, |id| id == &self.client_id)
+            && request.redirect_uri.as_ref() == Some(&self.redirect_uri)
+    }
+}
+
+pub struct AccessTokenMetadata {
+    pub client_id: Option<ClientIdBuf>,
+
+    /// JWK thumbprint (RFC 7638) the access token is DPoP-bound to, if any
+    /// (RFC 9449). When set, the resource server requires a matching DPoP proof.
+    pub jkt: Option<String>,
+}
+
+/// Authorization Code grant token request.
+///
+/// open_auth2 models PKCE (RFC 7636) as a client-side extension and keeps its
+/// core `AuthorizationCodeTokenRequest` PKCE-agnostic, so — being the server —
+/// we carry the `code_verifier` (§4.5) on our own request type here.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "grant_type", rename = "authorization_code")]
+pub struct AuthorizationCodeTokenRequest {
+    pub client_id: Option<ClientIdBuf>,
+    pub code: CodeBuf,
+    pub redirect_uri: Option<UriBuf>,
+    pub code_verifier: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum TokenRequest {
+    AuthorizationCode(AuthorizationCodeTokenRequest),
+    PreAuthorizedCode(PreAuthorizedCodeTokenRequest),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
+pub enum TokenType {
+    Bearer,
+    /// RFC 9449: a DPoP-bound access token.
+    #[serde(rename = "DPoP")]
+    Dpop,
+}
+
+impl TokenType {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Bearer => "Bearer",
+            Self::Dpop => "DPoP",
+        }
+    }
+}
+
+impl fmt::Display for TokenType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.as_str().fmt(f)
+    }
+}
+
+impl open_auth2::endpoints::token::TokenType for TokenType {}
+
+struct Redirect(UriBuf);
+
+impl IntoResponse for Redirect {
+    fn into_response(self) -> Response {
+        Response::builder()
+            .status(StatusCode::FOUND)
+            .header("Location", self.0.to_string())
+            .body(Body::empty())
+            .unwrap()
+    }
+}
+
+/// User decision relayed from the `manual_consent` page.
+#[derive(Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+enum Decision {
+    Approve,
+    Deny,
+}
+
+/// `/authorize/decision` query parameters.
+#[derive(Deserialize)]
+pub struct DecisionParams {
+    request_uri: UriBuf,
+    decision: Decision,
+}
+
+/// Completes an interactive authorization (`manual_consent` mode).
+///
+/// This is where the `request_uri` is finally consumed. On approval it issues
+/// the authorization code exactly like the auto-approving flow; on denial it
+/// redirects with `error=access_denied` (RFC 6749 §4.1.2.1).
+pub async fn authorize_decision(
+    State(server): State<Arc<Server>>,
+    Query(params): Query<DecisionParams>,
+) -> Response {
+    let Some((_, pa)) = server.oauth2.par.remove(&params.request_uri) else {
+        return Error::UnknownRequestUrl.into_response();
+    };
+
+    if pa.expires_at < UtcDateTime::now() {
+        return Error::Expired.into_response();
+    }
+
+    match params.decision {
+        Decision::Approve => server
+            .authorize_direct(pa.request, pa.dpop_jkt, pa.code_challenge)
+            .await
+            .into_response(),
+        Decision::Deny => {
+            let Stateful {
+                state,
+                value: request,
+            } = pa.request;
+            // RFC 6749 §4.1.2.1: the resource owner denying the request is
+            // reported to the client as `access_denied`.
+            let error = ErrorResponse::new("access_denied".to_owned(), None, None);
+            match request.deny(state, error, None) {
+                Some(uri) => Redirect(uri).into_response(),
+                None => Error::MissingRedirectUrl.into_response(),
+            }
+        }
+    }
+}

--- a/examples/issuer-conformance/oid4vci.rs
+++ b/examples/issuer-conformance/oid4vci.rs
@@ -1,0 +1,363 @@
+use std::{borrow::Cow, sync::Arc, time::Duration};
+
+use axum::{
+    extract::{Path, State},
+    http::{header::AUTHORIZATION, HeaderMap},
+};
+use base64::Engine as _;
+use dashmap::DashMap;
+use iref::UriBuf;
+use oid4vci::{
+    authorization::oauth2::dpop::{verify_dpop_proof, DPOP},
+    credential::CredentialOrConfigurationId,
+    endpoints::credential::{CredentialResponse, ImmediateCredentialResponse},
+    offer::{
+        CredentialOfferGrants, CredentialOfferParameters, PreAuthorizedCodeGrant, TxCodeDefinition,
+    },
+    profile::{
+        ProfileCredentialIssuerMetadata, ProfileCredentialRequest, ProfileCredentialResponse,
+    },
+    proof::{jwt::JwtProofVerifier, Proofs},
+    server::{CredentialErrorCode, Oid4vciServer, ServerError},
+    CredentialOffer, Oid4vciCredential, StandardProfile,
+};
+use open_auth2::AccessTokenBuf;
+use rand::distr::{Alphanumeric, SampleString};
+use sha2::{Digest, Sha256};
+use ssi::{
+    claims::jws::Jws,
+    dids::{AnyDidMethod, VerificationMethodDIDResolver},
+    prelude::AnyMethod,
+};
+use time::UtcDateTime;
+
+use crate::{oauth2::PreAuthorizedCodeMetadata, Error, Server};
+
+/// Lifetime of a `c_nonce` issued by the Nonce Endpoint.
+const NONCE_TTL: Duration = Duration::from_secs(300);
+
+/// Maximum accepted age of a DPoP proof's `iat` at the resource server.
+const DPOP_PROOF_MAX_AGE: Duration = Duration::from_secs(300);
+
+#[derive(Default)]
+pub struct Oid4vciState {
+    credential_offers: DashMap<String, CredentialOfferParameters>,
+
+    /// Nonces handed out by the Nonce Endpoint, with their expiry. A `c_nonce`
+    /// is valid until it expires and is consumed on first use (single-use), so
+    /// a replayed or unknown nonce is rejected (OpenID4VCI §8.2.3).
+    nonces: DashMap<String, UtcDateTime>,
+
+    /// `jti` values of accepted DPoP proofs, with their expiry, for replay
+    /// detection (RFC 9449 §11.1). Entries are kept for the proof validity
+    /// window and dropped once expired.
+    dpop_jtis: DashMap<String, UtcDateTime>,
+}
+
+impl Server {
+    /// Validates the DPoP proof presented with a DPoP-bound access token at the
+    /// resource server (RFC 9449 §7.1): the request must use the `DPoP`
+    /// authorization scheme and carry a `DPoP` proof valid for this request
+    /// (`POST` to the Credential Endpoint, recent `iat`), signed by the key the
+    /// access token is bound to (`jkt`), with an `ath` equal to the access token
+    /// hash.
+    async fn validate_dpop(
+        &self,
+        headers: &HeaderMap,
+        access_token: &AccessTokenBuf,
+        expected_jkt: &str,
+    ) -> Result<(), String> {
+        let scheme = headers
+            .get(&AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.split_once(' '))
+            .map(|(scheme, _)| scheme);
+        if !matches!(scheme, Some(s) if s.eq_ignore_ascii_case("dpop")) {
+            return Err("access token not presented with the DPoP scheme".to_owned());
+        }
+
+        // RFC 9449 §4.3: there must be exactly one DPoP proof header.
+        if headers.get_all(&DPOP).iter().count() != 1 {
+            return Err("expected exactly one DPoP proof header".to_owned());
+        }
+
+        let dpop = headers
+            .get(&DPOP)
+            .and_then(|v| v.to_str().ok())
+            .ok_or("missing DPoP proof header")?;
+        let dpop = Jws::new(dpop).map_err(|_| "malformed DPoP proof")?;
+
+        let htu = self.config.credential_endpoint();
+        let verified = verify_dpop_proof(dpop, "POST", &htu, DPOP_PROOF_MAX_AGE)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        // RFC 9449 §4.3: the `jwk` header must be a public key.
+        if !verified.jwk.is_public() {
+            return Err("DPoP proof `jwk` header contains private key material".to_owned());
+        }
+
+        // The proof key must be the one the access token is bound to.
+        let jkt = verified.jwk.thumbprint().map_err(|e| e.to_string())?;
+        if jkt != expected_jkt {
+            return Err(format!(
+                "DPoP proof key thumbprint `{jkt}` does not match the token binding `{expected_jkt}`"
+            ));
+        }
+
+        // RFC 9449 §4.3: `ath` is the base64url SHA-256 of the access token.
+        let expected_ath = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(Sha256::digest(access_token.as_bytes()));
+        if verified.proof.ath.as_deref() != Some(expected_ath.as_str()) {
+            return Err("DPoP proof `ath` does not match the access token".to_owned());
+        }
+
+        // RFC 9449 §11.1: detect replay by `jti` within the proof validity
+        // window. Reject a `jti` already seen; otherwise remember this one. Drop
+        // expired entries opportunistically to keep the set bounded.
+        let now = UtcDateTime::now();
+        self.oid4vci.dpop_jtis.retain(|_, expiry| *expiry >= now);
+        if self
+            .oid4vci
+            .dpop_jtis
+            .insert(verified.proof.jti.clone(), now + DPOP_PROOF_MAX_AGE)
+            .is_some()
+        {
+            return Err("DPoP proof `jti` has already been used".to_owned());
+        }
+
+        Ok(())
+    }
+
+    /// Validates the `c_nonce` carried by a key proof and consumes it.
+    ///
+    /// A missing nonce is an `invalid_proof`; an unknown, expired, or already
+    /// used nonce is an `invalid_nonce` (OpenID4VCI §8.3.1.2). Consuming on use
+    /// makes nonces single-use, rejecting replays.
+    fn consume_nonce(&self, nonce: Option<&str>) -> Result<(), ServerError> {
+        let nonce = nonce.ok_or_else(|| {
+            log::warn!("credential request: key proof is missing the c_nonce");
+            ServerError::CredentialRequest(
+                CredentialErrorCode::InvalidProof,
+                Some("key proof is missing the c_nonce".to_owned()),
+            )
+        })?;
+
+        match self.oid4vci.nonces.remove(nonce) {
+            Some((_, expiry)) if expiry >= UtcDateTime::now() => Ok(()),
+            _ => {
+                log::warn!("credential request: c_nonce is unknown, expired, or already used");
+                Err(ServerError::CredentialRequest(
+                    CredentialErrorCode::InvalidNonce,
+                    Some("the c_nonce is invalid or expired".to_owned()),
+                ))
+            }
+        }
+    }
+}
+
+impl Oid4vciServer for Server {
+    type Profile = StandardProfile;
+
+    async fn metadata(
+        &self,
+    ) -> Result<Cow<'_, ProfileCredentialIssuerMetadata<Self::Profile>>, ServerError> {
+        Ok(Cow::Owned(self.config.credential_issuer_metadata()))
+    }
+
+    async fn nonce(&self) -> Result<String, ServerError> {
+        // Generate a fresh `c_nonce` and remember it so the Credential Endpoint
+        // can later verify the proof was bound to a nonce we issued.
+        let nonce = Alphanumeric.sample_string(&mut rand::rng(), 32);
+        self.oid4vci
+            .nonces
+            .insert(nonce.clone(), UtcDateTime::now() + NONCE_TTL);
+        Ok(nonce)
+    }
+
+    async fn credential(
+        &self,
+        headers: HeaderMap,
+        access_token: AccessTokenBuf,
+        request: ProfileCredentialRequest<Self::Profile>,
+    ) -> Result<ProfileCredentialResponse<Self::Profile>, ServerError> {
+        log::debug!("credential request: {request:#?}");
+
+        let m = self
+            .oauth2
+            .access_token_metadata(&access_token)
+            .ok_or_else(|| {
+                log::warn!("credential request: unknown access token");
+                ServerError::Unauthorized
+            })?;
+
+        // When the access token is DPoP-bound, the resource server MUST validate
+        // the accompanying DPoP proof (RFC 9449 §7.1).
+        if let Some(expected_jkt) = &m.jkt {
+            self.validate_dpop(&headers, &access_token, expected_jkt)
+                .await
+                .map_err(|e| {
+                    log::warn!("credential request: DPoP validation failed: {e}");
+                    ServerError::Unauthorized
+                })?;
+        }
+
+        let (config, value) = match request.credential {
+            CredentialOrConfigurationId::Credential(id) => {
+                self.config.get_credential(&id).ok_or_else(|| {
+                    log::warn!("credential request: unknown credential identifier {id:?}");
+                    ServerError::CredentialRequest(
+                        CredentialErrorCode::UnknownCredentialIdentifier,
+                        None,
+                    )
+                })?
+            }
+            CredentialOrConfigurationId::Configuration(id) => {
+                let config = self
+                    .config
+                    .credential_configurations
+                    .get(&id)
+                    .ok_or_else(|| {
+                        log::warn!("credential request: unknown credential configuration {id:?}");
+                        ServerError::CredentialRequest(
+                            CredentialErrorCode::UnknownCredentialConfiguration,
+                            None,
+                        )
+                    })?;
+                let mut credentials = config.credentials.iter();
+                let (_, value) = credentials.next().ok_or(ServerError::Unauthorized)?;
+                if credentials.next().is_some() {
+                    return Err(ServerError::Unauthorized);
+                }
+
+                (config, value)
+            }
+        };
+
+        let issuer = self.config.credential_issuer();
+
+        let credentials = match &request.proofs {
+            Some(proofs) => {
+                let verified = match proofs {
+                    Proofs::Jwt(jwts) => {
+                        let jwk_resolver = VerificationMethodDIDResolver::<_, AnyMethod>::new(
+                            AnyDidMethod::default(),
+                        );
+                        let verifier = JwtProofVerifier::new(&issuer, &jwk_resolver);
+
+                        verifier
+                            .verify_list(m.client_id.as_deref(), jwts)
+                            .await
+                            .map_err(|e| {
+                                log::warn!("credential request: proof verification failed: {e}");
+                                ServerError::CredentialRequest(
+                                    CredentialErrorCode::InvalidProof,
+                                    None,
+                                )
+                            })?
+                    }
+                    _ => todo!(),
+                };
+
+                let mut credentials = Vec::with_capacity(verified.len());
+
+                for proof in verified {
+                    // The proof MUST be bound to a fresh, server-issued nonce
+                    // (OpenID4VCI §8.2.3); reject missing/invalid/replayed ones.
+                    self.consume_nonce(proof.nonce.as_deref())?;
+
+                    credentials.push(Oid4vciCredential::new(
+                        config
+                            .sign(
+                                issuer.as_str(),
+                                &self.jwk,
+                                m.client_id.as_deref(),
+                                value,
+                                Some(&proof.key),
+                            )
+                            .await,
+                    ));
+                }
+
+                credentials
+            }
+            None => {
+                // Every credential configuration here advertises
+                // `proof_types_supported`, so a key proof is REQUIRED
+                // (OpenID4VCI §8.2). A request without `proofs` is an
+                // `invalid_proof` error (§8.3.1.2).
+                log::warn!("credential request: missing required proofs");
+                return Err(ServerError::CredentialRequest(
+                    CredentialErrorCode::InvalidProof,
+                    Some("the credential configuration requires a key proof".to_owned()),
+                ));
+            }
+        };
+
+        Ok(CredentialResponse::Immediate(
+            ImmediateCredentialResponse::new(credentials),
+        ))
+    }
+}
+
+pub async fn credential_offer(
+    State(server): State<Arc<Server>>,
+    Path(credential_offer_id): Path<String>,
+) -> Result<CredentialOfferParameters, Error> {
+    let params = server
+        .oid4vci
+        .credential_offers
+        .get(&credential_offer_id)
+        .ok_or(Error::UnknownCredentialOffer)?;
+
+    Ok(params.clone())
+}
+
+pub async fn new_credential_offer(State(server): State<Arc<Server>>) -> String {
+    let grants = if server.config.pre_auth {
+        let pa_code = server
+            .oauth2
+            .new_pre_authorized_code(PreAuthorizedCodeMetadata {
+                tx_code: server.config.tx_code.clone(),
+            });
+
+        let mut grant = PreAuthorizedCodeGrant::new(pa_code);
+
+        if server.config.tx_code.is_some() {
+            grant.tx_code = Some(TxCodeDefinition::default())
+        }
+
+        CredentialOfferGrants {
+            pre_authorized_code: Some(grant),
+            ..Default::default()
+        }
+    } else {
+        CredentialOfferGrants {
+            authorization_code: Some(Default::default()),
+            ..Default::default()
+        }
+    };
+
+    let base_url = server.config.credential_issuer();
+    let params = CredentialOfferParameters {
+        credential_issuer: base_url.clone(),
+        credential_configuration_ids: server
+            .config
+            .credential_configurations
+            .keys()
+            .cloned()
+            .collect(),
+        grants,
+    };
+
+    let credential_offer = if server.config.by_ref {
+        let id = Alphanumeric.sample_string(&mut rand::rng(), 30);
+        server.oid4vci.credential_offers.insert(id.clone(), params);
+        let uri = UriBuf::new(format!("{base_url}/offer/{id}").into_bytes()).unwrap();
+        CredentialOffer::Reference(uri)
+    } else {
+        CredentialOffer::Value(params)
+    };
+
+    credential_offer.to_uri().into_string()
+}

--- a/examples/issuer-conformance/setup.sh
+++ b/examples/issuer-conformance/setup.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+cd $(dirname "$0")
+
+# Parse options.
+#
+# --public-url URL   The public URL the conformance suite reaches the issuer at
+#                    (e.g. the ngrok URL). Fills `vci.credential_issuer_url`.
+public_url=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --public-url) public_url="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+# Generate cryptographic material.
+echo "Generating cryptographic material..."
+crypto/generate.sh
+
+echo "Building test configuration..."
+
+# Base filter: fields derived from the generated cryptographic material.
+filter='.credential.trust_anchor_pem = $root_cert
+  | .credential.status_list_trust_anchor_pem = $root_cert
+  | .client.client_id = $client_id
+  | .client2.client_id = $client2_id
+  | .client_attestation.attester_jwks = {keys: [$attester_key]}
+  | .client_attestation.issuer = $attester_did
+  | .client_attestation.key_attestation_jwks = {keys: [$key_attestation_key]}'
+
+if [ -n "$public_url" ]; then
+  # The issuer is also the Authorization Server, so both point at the public URL.
+  filter="$filter
+    | .vci.credential_issuer_url = \$public_url
+    | .vci.authorization_server = \$public_url"
+fi
+
+cat test.template.json | jq \
+   --arg root_cert "$(cat crypto/ca/cert.pem)" \
+   --arg client_id "$(cat crypto/wallet/did)" \
+   --arg client2_id "$(cat crypto/wallet2/did)" \
+   --argjson attester_key "$(cat crypto/attester/jwk.json)" \
+   --arg attester_did "$(cat crypto/attester/did)" \
+   --argjson key_attestation_key "$(cat crypto/key-attestation/jwk.json)" \
+   --arg public_url "$public_url" \
+   "$filter" \
+   > test.json
+
+echo "Test configuration available at:"
+echo "$(dirname $0)/test.json"
+echo
+if [ -z "$public_url" ]; then
+  echo
+  echo "NOTE: vci.credential_issuer_url was not set. Pass --public-url <URL>, or"
+  echo "      edit it in test.json before uploading (the others are optional and"
+  echo "      have sensible defaults: credential_configuration_id, proof_type_hint,"
+  echo "      authorization_server)."
+fi

--- a/examples/issuer-conformance/test.template.json
+++ b/examples/issuer-conformance/test.template.json
@@ -1,0 +1,25 @@
+{
+  "alias": "my-oid4vci-issuer-test",
+  "description": "OID4VCI 1.0 Final issuer conformance",
+  "vci": {
+    "credential_issuer_url": "https://localhost:8080",
+    "credential_configuration_id": "eu.europa.ec.eudi.pid.1",
+    "credential_proof_type_hint": "",
+    "authorization_server": ""
+  },
+  "credential": {
+    "trust_anchor_pem": "",
+    "status_list_trust_anchor_pem": ""
+  },
+  "client": {
+    "client_id": ""
+  },
+  "client2": {
+    "client_id": ""
+  },
+  "client_attestation": {
+    "attester_jwks": {},
+    "issuer": "",
+    "key_attestation_jwks": {}
+  }
+}

--- a/src/authorization/oauth2/dpop/mod.rs
+++ b/src/authorization/oauth2/dpop/mod.rs
@@ -44,6 +44,14 @@ pub const DPOP_NONCE: HeaderName = HeaderName::from_static("dpop-nonce");
 /// DPoP Proof JWT `typ` claim value.
 pub const DPOP_JWT_TYP: &str = "dpop+jwt";
 
+/// Clock-skew leeway applied to a DPoP proof's `iat` when accepting a proof
+/// minted slightly in the future.
+///
+/// RFC 9449 §4.3 leaves the acceptable `iat` window to the server; FAPI2
+/// requires tolerating reasonable skew between the client's and server's
+/// clocks, so a proof up to this far in the future is still accepted.
+pub const DPOP_IAT_LEEWAY: Duration = Duration::from_secs(60);
+
 /// DPoP Proof.
 ///
 /// See: <https://www.rfc-editor.org/rfc/rfc9449#section-4.2>
@@ -196,13 +204,20 @@ impl<K, S> ValidateClaims<DpopProofVerificationParams<'_, K>, S> for DpopProof {
         _proof: &S,
     ) -> ClaimsValidity {
         let now = params.date_time();
-        self.iat.verify(now)?;
 
-        // RFC 9449 §4.3: the `iat` must be within an acceptable window.
+        // RFC 9449 §4.3: the `iat` must be within an acceptable window. The
+        // window is asymmetric: a proof may be up to `max_age` old, and — to
+        // tolerate clock skew between the client and this server (required by
+        // FAPI2) — up to `DPOP_IAT_LEEWAY` in the future. ssi's
+        // `IssuedAt::verify` rejects any future `iat` with zero leeway, so the
+        // window is enforced manually here instead.
         if let Some(max_age) = params.max_age {
             let age = now.timestamp() as f64 - self.iat.0.as_seconds();
             if age > max_age.as_secs_f64() {
                 return Err(InvalidClaims::other("`iat` claim is too old"));
+            }
+            if age < -DPOP_IAT_LEEWAY.as_secs_f64() {
+                return Err(InvalidClaims::other("`iat` claim is too far in the future"));
             }
         }
 


### PR DESCRIPTION
Adds `examples/issuer-conformance`, the issuer-side counterpart to `examples/wallet-conformance`: a thin Credential Issuer + OAuth2 Authorization Server (PAR, DPoP, Attestation-Based Client Auth, SD-JWT VC) that drives the library through the OpenID Foundation conformance suite acting as the wallet. One server serves both the `oid4vci-1_0-issuer-*` and `fapi2-security-profile-final-*` plans, with shared crypto + `test.json` generation (`setup.sh`) and a README covering setup, the TLS/BCP-195 deployment, and how to run the interactive tests.
