### PR TITLE
Multi-tenant support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,14 +28,14 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = "3.3.0"
 serde_path_to_error = "0.1.14"
-open-auth2 = { git = "https://github.com/spruceid/open-auth2-rs", rev = "c03bc2e" }
+open-auth2 = { git = "https://github.com/spruceid/open-auth2-rs", rev = "5d653ea" }
 base64 = "0.21.4"
 rand = "0.9.2"
 time = { version = "0.3.29", features = ["serde"] }
 thiserror = "1.0.49"
 serde_urlencoded = "0.7.1"
 indexmap = "2.13.0"
-iref = { version = "3.2.2", features = ["macros"] }
+iref = "4.1"
 pct-str = "2.0.0"
 langtag = { version = "0.4.0", features = ["serde"] }
 json-ld = "0.21.2"

--- a/examples/issuer-conformance/oauth2.rs
+++ b/examples/issuer-conformance/oauth2.rs
@@ -351,6 +351,7 @@ impl OAuth2Server for Server {
 
     async fn metadata(
         &self,
+        _path: Option<&iref::uri::Path>,
     ) -> Result<Cow<'_, Oid4vciAuthorizationServerMetadata>, OAuth2ServerError> {
         Ok(match &self.config.authorization_server_metadata {
             Some(metadata) => Cow::Borrowed(metadata),

--- a/examples/issuer-conformance/oid4vci.rs
+++ b/examples/issuer-conformance/oid4vci.rs
@@ -161,6 +161,7 @@ impl Oid4vciServer for Server {
 
     async fn metadata(
         &self,
+        _path: Option<&iref::uri::Path>,
     ) -> Result<Cow<'_, ProfileCredentialIssuerMetadata<Self::Profile>>, ServerError> {
         Ok(Cow::Owned(self.config.credential_issuer_metadata()))
     }

--- a/examples/server/oauth2.rs
+++ b/examples/server/oauth2.rs
@@ -104,6 +104,7 @@ impl OAuth2Server for Server {
 
     async fn metadata(
         &self,
+        _path: Option<&iref::uri::Path>,
     ) -> Result<Cow<'_, Oid4vciAuthorizationServerMetadata>, OAuth2ServerError> {
         Ok(match &self.config.authorization_server_metadata {
             Some(metadata) => Cow::Borrowed(metadata),

--- a/examples/server/oid4vci.rs
+++ b/examples/server/oid4vci.rs
@@ -35,6 +35,7 @@ impl Oid4vciServer for Server {
 
     async fn metadata(
         &self,
+        _path: Option<&iref::uri::Path>,
     ) -> Result<Cow<'_, ProfileCredentialIssuerMetadata<Self::Profile>>, ServerError> {
         Ok(Cow::Owned(self.config.credential_issuer_metadata()))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,7 @@
 //! [`AnyProfile`]: crate::profile::AnyProfile
 //! [`StandardProfile`]: crate::profile::StandardProfile
 //! [Appendix A]: <https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-format-profiles>
+pub use indexmap;
 pub use iref;
 pub use open_auth2;
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,12 +2,13 @@ use std::{borrow::Cow, future::Future, sync::Arc};
 
 use axum::{
     body::Body,
-    extract::State,
+    extract::{Path as PathParam, State},
     http::{header, HeaderMap, StatusCode},
     response::{IntoResponse, Response},
     routing::{get, post},
     Json,
 };
+use iref::uri::Path;
 use open_auth2::{server::ErrorResponse, AccessTokenBuf};
 use serde::{Deserialize, Serialize};
 
@@ -26,11 +27,23 @@ use crate::{
 pub trait Oid4vciServer: Sized + Send + Sync + 'static {
     type Profile: Profile;
 
-    /// Credential Issuer Metadata.
+    /// Returns the credential issuer metadata for the given tenant path.
     ///
-    /// See: <https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-issuer-metadata>
+    /// The `path` argument is the suffix of the well-known metadata URL after
+    /// `/.well-known/openid-credential-issuer`, and identifies the tenant
+    /// issuer as defined in [OpenID4VCI §11.2.2]:
+    ///
+    /// | Request path | `path` argument | Issuer |
+    /// |---|---|---|
+    /// | `/.well-known/openid-credential-issuer` | `None` | `https://example.com` |
+    /// | `/.well-known/openid-credential-issuer/` | `Some("")` | `https://example.com/` |
+    /// | `/.well-known/openid-credential-issuer/tenant` | `Some("tenant")` | `https://example.com/tenant` |
+    /// | `/.well-known/openid-credential-issuer/foo/bar` | `Some("foo/bar")` | `https://example.com/foo/bar` |
+    ///
+    /// [OpenID4VCI §11.2.2]: https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-issuer-metadata
     fn metadata(
         &self,
+        path: Option<&Path>,
     ) -> impl Send
            + Future<
         Output = Result<Cow<'_, ProfileCredentialIssuerMetadata<Self::Profile>>, ServerError>,
@@ -101,22 +114,60 @@ pub trait Oid4vciRouter<S: Oid4vciServer> {
 
 impl<S: Oid4vciServer> Oid4vciRouter<S> for axum::Router<Arc<S>> {
     fn oid4vci_routes(self) -> Self {
-        self.route("/.well-known/openid-credential-issuer", get(metadata::<S>))
-            .route("/nonce", post(nonce::<S>))
-            .route("/credential", post(credential::<S>))
-            .route("/deferred_credential", post(deferred_credential::<S>))
-            .route("/notification", post(notification::<S>))
+        self.route(
+            "/.well-known/openid-credential-issuer",
+            get(metadata_none::<S>),
+        )
+        .route(
+            "/.well-known/openid-credential-issuer/",
+            get(metadata_some_empty::<S>),
+        )
+        .route(
+            "/.well-known/openid-credential-issuer/{*tenant}",
+            get(metadata_some_non_empty::<S>),
+        )
+        .route("/nonce", post(nonce::<S>))
+        .route("/credential", post(credential::<S>))
+        .route("/deferred_credential", post(deferred_credential::<S>))
+        .route("/notification", post(notification::<S>))
     }
 }
 
-/// Credential Issuer Metadata Endpoint.
-async fn metadata<S>(State(server): State<Arc<S>>) -> impl IntoResponse
+async fn metadata_none<S>(State(server): State<Arc<S>>) -> impl IntoResponse
 where
     S: Oid4vciServer,
 {
     // TODO support `Accept-Language` header.
     server
-        .metadata()
+        .metadata(None)
+        .await
+        .map(|metadata| metadata.as_ref().into_response())
+}
+
+async fn metadata_some_empty<S>(State(server): State<Arc<S>>) -> impl IntoResponse
+where
+    S: Oid4vciServer,
+{
+    // TODO support `Accept-Language` header.
+    server
+        .metadata(Some(Path::EMPTY_RELATIVE))
+        .await
+        .map(|metadata| metadata.as_ref().into_response())
+}
+
+async fn metadata_some_non_empty<S>(
+    State(server): State<Arc<S>>,
+    PathParam(tenant): PathParam<String>,
+) -> impl IntoResponse
+where
+    S: Oid4vciServer,
+{
+    // TODO support `Accept-Language` header.
+    let path = Path::new(&tenant)
+        // UNWRAP SAFETY: axum wildcard paths are always valid iref paths.
+        .unwrap();
+    server
+        .metadata(Some(path))
         .await
         .map(|metadata| metadata.as_ref().into_response())
 }
@@ -259,6 +310,9 @@ pub enum CredentialErrorCode {
 
 #[derive(Debug, thiserror::Error)]
 pub enum ServerError {
+    #[error("not found")]
+    NotFound,
+
     #[error("unauthorized: {0}")]
     Unauthorized(Cow<'static, str>),
 
@@ -274,9 +328,19 @@ pub enum ServerError {
     Other(String),
 }
 
+impl ServerError {
+    pub fn other(e: impl ToString) -> Self {
+        Self::Other(e.to_string())
+    }
+}
+
 impl IntoResponse for ServerError {
     fn into_response(self) -> Response {
         match self {
+            Self::NotFound => Response::builder()
+                .status(StatusCode::NOT_FOUND)
+                .body(Body::empty())
+                .unwrap(),
             // RFC 6750 §3: a 401 response to a protected-resource request carries
             // a `WWW-Authenticate` challenge; the reason is surfaced in
             // `error_description` to make the rejection easier to debug.


### PR DESCRIPTION
When the issuer id is of the form `https://hostname/foo/bar`, the issuer metadata is fetched at `.well-known/openid-credential-issuer/foo/bar` allowing the same OID4VCI server to have multiple "tenants", which is currently not supported by this implementation. This PR adds proper support for multiple tenants on the same issuer server by passing the metadata URI path part to the `metadata` method.

# Other changes

- Bump `iref` to version 4 <- this may be annoying because `ssi` uses v3, but there should be no interaction between the two afaik. And I plan to bump it in `ssi` too anyway as soon as I can.
- Add some convenience impls.

Tested on ca-credible.